### PR TITLE
[FEATURE] 주문 내역을 조회하는 기능 구현

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/controller/OrderController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/controller/OrderController.java
@@ -1,0 +1,42 @@
+package com.jamjam.bookjeok.domains.order.command.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.query.service.MemberQueryService;
+import com.jamjam.bookjeok.domains.order.command.dto.PageOrderResponse;
+import com.jamjam.bookjeok.domains.order.command.service.OrderCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final MemberQueryService memberQueryService;
+    private final OrderCommandService orderCommandService;
+
+    @GetMapping("/members/{memberId}/orders")
+    public ResponseEntity<ApiResponse<PageOrderResponse>> getOrders(
+            @PathVariable(value = "memberId") String memberId,
+            @PageableDefault(sort = "orderedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
+        Long memberUid = memberDetail.getMember().getMemberUid();
+
+        PageOrderResponse pageOrderResponseWrapper = orderCommandService.getOrdersByMemberUid(pageable, memberUid);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(pageOrderResponseWrapper));
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/dto/OrderResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/dto/OrderResponse.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.order.command.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record OrderResponse(
+    Long orderUid, String orderId, String orderName, int totalAmount, String orderStatusName,
+    LocalDateTime orderedAt, LocalDateTime canceledAt, LocalDateTime changedAt, LocalDateTime refundedAt
+) {
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/dto/PageOrderResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/dto/PageOrderResponse.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.order.command.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PageOrderResponse(
+        List<OrderResponse> orders, int pageNumber, int pageSize,
+        long totalElements, int totalPages
+) {
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/repository/OrderRepository.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/repository/OrderRepository.java
@@ -1,8 +1,24 @@
 package com.jamjam.bookjeok.domains.order.command.repository;
 
+import com.jamjam.bookjeok.domains.order.command.dto.OrderResponse;
 import com.jamjam.bookjeok.domains.order.command.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @Query("""
+        SELECT new com.jamjam.bookjeok.domains.order.command.dto.OrderResponse(
+            o.orderUid, o.orderId, o.orderName, o.totalAmount, os.orderStatusName, 
+            o.orderedAt, o.canceledAt, o.modifiedAt, o.refundedAt
+        )
+        FROM Order o
+        JOIN OrderStatus os ON o.orderStatusId = os.orderStatusId
+        WHERE o.memberUid = :memberUid
+    """)
+    Page<OrderResponse> findAllOrdersByMemberUid(Pageable pageable, @Param("memberUid") Long memberUid);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/service/OrderCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/service/OrderCommandService.java
@@ -1,11 +1,14 @@
 package com.jamjam.bookjeok.domains.order.command.service;
 
-
+import com.jamjam.bookjeok.domains.order.command.dto.PageOrderResponse;
 import com.jamjam.bookjeok.domains.order.command.entity.Order;
 import com.jamjam.bookjeok.domains.payment.command.dto.PaymentDTO;
 import com.jamjam.bookjeok.domains.pendingorder.command.entity.PendingOrder;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderCommandService {
+
+    PageOrderResponse getOrdersByMemberUid(Pageable pageable, Long memberUid);
 
     Order createOrder(PendingOrder findPendingOrder, PaymentDTO paymentDTO);
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/service/OrderCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/command/service/OrderCommandServiceImpl.java
@@ -1,11 +1,14 @@
 package com.jamjam.bookjeok.domains.order.command.service;
 
-
+import com.jamjam.bookjeok.domains.order.command.dto.OrderResponse;
+import com.jamjam.bookjeok.domains.order.command.dto.PageOrderResponse;
 import com.jamjam.bookjeok.domains.order.command.entity.Order;
 import com.jamjam.bookjeok.domains.order.command.repository.OrderRepository;
 import com.jamjam.bookjeok.domains.payment.command.dto.PaymentDTO;
 import com.jamjam.bookjeok.domains.pendingorder.command.entity.PendingOrder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderCommandServiceImpl implements OrderCommandService {
 
     private final OrderRepository orderRepository;
+
+    @Override
+    public PageOrderResponse getOrdersByMemberUid(Pageable pageable, Long memberUid) {
+        Page<OrderResponse> pageOrderResponse = orderRepository.findAllOrdersByMemberUid(pageable, memberUid);
+        return toPageOrderResponse(pageOrderResponse);
+    }
 
     @Override
     public Order createOrder(PendingOrder findPendingOrder, PaymentDTO paymentDTO) {
@@ -28,6 +37,16 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .totalAmount(paymentDTO.totalAmount())
                 .build();
         return orderRepository.save(order);
+    }
+
+    private PageOrderResponse toPageOrderResponse(Page<OrderResponse> pageOrderResponse) {
+        return PageOrderResponse.builder()
+                .orders(pageOrderResponse.getContent())
+                .pageNumber(pageOrderResponse.getNumber())
+                .pageSize(pageOrderResponse.getSize())
+                .totalElements(pageOrderResponse.getTotalElements())
+                .totalPages(pageOrderResponse.getTotalPages())
+                .build();
     }
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/application.yml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/application.yml
@@ -1,9 +1,16 @@
 spring:
   application:
     name: bookjeok-service
+
   config:
     activate:
       on-profile: local
+
+  data:
+    web:
+      pageable:
+        default-page-size: 10
+        max-page-size: 1000
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/order/command/controller/OrderControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/order/command/controller/OrderControllerTest.java
@@ -1,0 +1,116 @@
+package com.jamjam.bookjeok.domains.order.command.controller;
+
+import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.query.service.MemberQueryServiceImpl;
+import com.jamjam.bookjeok.domains.order.command.dto.OrderResponse;
+import com.jamjam.bookjeok.domains.order.command.dto.PageOrderResponse;
+import com.jamjam.bookjeok.domains.order.command.service.OrderCommandServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrderController.class)
+@ImportAutoConfiguration(exclude = SecurityAutoConfiguration.class)
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberQueryServiceImpl memberQueryService;
+
+    @MockBean
+    private OrderCommandServiceImpl orderCommandService;
+
+    private List<OrderResponse> orders;
+
+    @BeforeEach
+    void setUp() {
+        orders = List.of(
+                OrderResponse.builder()
+                        .orderUid(56L)
+                        .orderId("ORD001")
+                        .orderName("도서 주문 1")
+                        .totalAmount(25000)
+                        .orderStatusName("결제승인")
+                        .orderedAt(LocalDateTime.of(2025, 4, 9, 10, 0, 0))
+                        .canceledAt(null)
+                        .changedAt(null)
+                        .refundedAt(null)
+                        .build(),
+
+                OrderResponse.builder()
+                        .orderUid(57L)
+                        .orderId("ORD002")
+                        .orderName("도서 주문 2")
+                        .totalAmount(31000)
+                        .orderStatusName("결제승인")
+                        .orderedAt(LocalDateTime.of(2025, 4, 10, 10, 0, 0))
+                        .canceledAt(null)
+                        .changedAt(null)
+                        .refundedAt(null)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("회원id로 주문 정보를 조회하는 테스트")
+    void testGetOrders() throws Exception {
+        // given
+        String memberId = "test01";
+        Long memberUid = 1L;
+
+        PageOrderResponse pageOrderResponse = PageOrderResponse.builder()
+                .orders(orders)
+                .pageNumber(0)
+                .pageSize(10)
+                .totalElements(2)
+                .totalPages(1)
+                .build();
+
+        MemberDetailResponse memberDetailResponse = MemberDetailResponse.builder()
+                .member(new MemberDTO(memberUid, null, null, null,
+                        null, null, null, true,
+                        null, null, null, null))
+                .build();
+
+        when(memberQueryService.getMemberDetail(memberId)).thenReturn(memberDetailResponse);
+        when(orderCommandService.getOrdersByMemberUid(any(Pageable.class), eq(memberUid))).thenReturn(pageOrderResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/members/{memberId}/orders", memberId)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orders").isArray())
+                .andExpect(jsonPath("$.data.pageNumber").value(0))
+                .andExpect(jsonPath("$.data.pageSize").value(10))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/order/command/service/OrderCommandServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/order/command/service/OrderCommandServiceImplTest.java
@@ -1,0 +1,89 @@
+package com.jamjam.bookjeok.domains.order.command.service;
+
+import com.jamjam.bookjeok.domains.order.command.dto.OrderResponse;
+import com.jamjam.bookjeok.domains.order.command.dto.PageOrderResponse;
+import com.jamjam.bookjeok.domains.order.command.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderCommandServiceImplTest {
+
+    @InjectMocks
+    private OrderCommandServiceImpl orderCommandService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    private List<OrderResponse> orders;
+
+    @BeforeEach
+    void setUp() {
+        orders = List.of(
+                OrderResponse.builder()
+                        .orderUid(56L)
+                        .orderId("ORD001")
+                        .orderName("도서 주문 1")
+                        .totalAmount(25000)
+                        .orderStatusName("결제승인")
+                        .orderedAt(LocalDateTime.of(2025, 4, 9, 10, 0, 0))
+                        .canceledAt(null)
+                        .changedAt(null)
+                        .refundedAt(null)
+                        .build(),
+
+                OrderResponse.builder()
+                        .orderUid(57L)
+                        .orderId("ORD002")
+                        .orderName("도서 주문 2")
+                        .totalAmount(31000)
+                        .orderStatusName("결제승인")
+                        .orderedAt(LocalDateTime.of(2025, 4, 10, 10, 0, 0))
+                        .canceledAt(null)
+                        .changedAt(null)
+                        .refundedAt(null)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("회원uid 주문 목록을 조회하는 테스트")
+    void testGetOrdersByMemberUid() {
+        // given
+        Long memberUid = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<OrderResponse> mockPage = new PageImpl<>(orders, pageable, orders.size());
+
+        when(orderRepository.findAllOrdersByMemberUid(pageable, memberUid)).thenReturn(mockPage);
+
+        // when
+        PageOrderResponse pageOrderResponse = orderCommandService.getOrdersByMemberUid(pageable, memberUid);
+
+        // then
+        assertThat(pageOrderResponse).isNotNull();
+        assertThat(pageOrderResponse.orders()).hasSize(2);
+        assertThat(pageOrderResponse.pageNumber()).isEqualTo(0);
+        assertThat(pageOrderResponse.pageSize()).isEqualTo(10);
+        assertThat(pageOrderResponse.totalElements()).isEqualTo(2);
+        assertThat(pageOrderResponse.totalPages()).isEqualTo(1);
+
+        verify(orderRepository, times(1)).findAllOrdersByMemberUid(pageable, memberUid);
+    }
+
+}


### PR DESCRIPTION
## 구현한 내용
- GET /api/v1/members/{memberId}/orders API 구현
- memberId로 회원 정보 조회 후 memberUid 기반으로 주문 목록 조회
- 주문 상태, 주문일 등 상세 정보 포함
- Pageable을 활용한 페이징 처리
- DTO (OrderResponse, PageOrderResponse) 및 ApiResponse 포맷으로 응답 반환

---

Close: #8 
 