### PR TITLE
[REFACTOR] 결제 승인 API 엔드포인트를 REST 규약에 더 부합하도록 수정

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/controller/PaymentCommandController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/controller/PaymentCommandController.java
@@ -19,11 +19,12 @@ public class PaymentCommandController {
 
     private final PaymentCommandService paymentCommandService;
 
-    @PostMapping("/payment/confirm")
+    @PostMapping("/payment/{paymentKey}/confirm")
     public ResponseEntity<ApiResponse<PaymentConfirmResponse>> confirmPayment(
+            @PathVariable(value = "paymentKey") String paymentKey,
             @RequestBody @Validated PaymentConfirmRequest paymentConfirmRequest
     ) {
-        PaymentConfirmResponse paymentConfirmResponse = paymentCommandService.confirmPayment(paymentConfirmRequest);
+        PaymentConfirmResponse paymentConfirmResponse = paymentCommandService.confirmPayment(paymentKey, paymentConfirmRequest);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/dto/TossPaymentApproveRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/dto/TossPaymentApproveRequest.java
@@ -1,0 +1,9 @@
+package com.jamjam.bookjeok.domains.payment.command.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TossPaymentApproveRequest(
+        String paymentKey, String orderId, int amount
+) {
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/dto/request/PaymentConfirmRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/dto/request/PaymentConfirmRequest.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 @Builder
 public record PaymentConfirmRequest(
         @NotBlank(message = "orderId가 없으면 결제를 완료할 수 없습니다.") String orderId,
-        @NotBlank(message = "paymentKey가 없으면 결제를 완료할 수 없습니다.") String paymentKey,
         @Min(value = 1, message = "올바르지 않은 결제 금액입니다.") int amount
 ) {
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/infrastructure/service/TossPaymentCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/infrastructure/service/TossPaymentCommandService.java
@@ -1,10 +1,10 @@
 package com.jamjam.bookjeok.domains.payment.command.infrastructure.service;
 
 import com.jamjam.bookjeok.domains.payment.command.dto.PaymentDTO;
-import com.jamjam.bookjeok.domains.payment.command.dto.request.PaymentConfirmRequest;
+import com.jamjam.bookjeok.domains.payment.command.dto.TossPaymentApproveRequest;
 
 public interface TossPaymentCommandService {
 
-    PaymentDTO approvePayment(PaymentConfirmRequest paymentConfirmRequest);
+    PaymentDTO approvePayment(TossPaymentApproveRequest tossPaymentApproveRequest);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/infrastructure/service/TossPaymentCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/infrastructure/service/TossPaymentCommandServiceImpl.java
@@ -2,7 +2,7 @@ package com.jamjam.bookjeok.domains.payment.command.infrastructure.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jamjam.bookjeok.domains.payment.command.dto.PaymentDTO;
-import com.jamjam.bookjeok.domains.payment.command.dto.request.PaymentConfirmRequest;
+import com.jamjam.bookjeok.domains.payment.command.dto.TossPaymentApproveRequest;
 import com.jamjam.bookjeok.exception.payment.ExternalPaymentException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,10 +34,10 @@ public class TossPaymentCommandServiceImpl implements TossPaymentCommandService 
     private final ObjectMapper objectMapper;
 
     @Override
-    public PaymentDTO approvePayment(PaymentConfirmRequest paymentConfirmRequest) {
+    public PaymentDTO approvePayment(TossPaymentApproveRequest tossPaymentApproveRequest) {
         try {
             HttpURLConnection connection = createConnection();
-            sendRequest(connection, paymentConfirmRequest);
+            sendRequest(connection, tossPaymentApproveRequest);
 
             int code = connection.getResponseCode();
             boolean isSuccess = code == HTTP_STATUS_CODE_OK;
@@ -67,8 +67,8 @@ public class TossPaymentCommandServiceImpl implements TossPaymentCommandService 
         return connection;
     }
 
-    private void sendRequest(HttpURLConnection connection, PaymentConfirmRequest paymentConfirmRequest) throws IOException {
-        String requestJson = objectMapper.writeValueAsString(paymentConfirmRequest);
+    private void sendRequest(HttpURLConnection connection, TossPaymentApproveRequest tossPaymentApproveRequest) throws IOException {
+        String requestJson = objectMapper.writeValueAsString(tossPaymentApproveRequest);
         log.info("requestJson = {}", requestJson);
 
         try (OutputStream os = connection.getOutputStream()) {

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandService.java
@@ -5,6 +5,6 @@ import com.jamjam.bookjeok.domains.payment.command.dto.response.PaymentConfirmRe
 
 public interface PaymentCommandService {
 
-    PaymentConfirmResponse confirmPayment(PaymentConfirmRequest paymentConfirmRequest);
+    PaymentConfirmResponse confirmPayment(String paymentKey, PaymentConfirmRequest paymentConfirmRequest);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/static/success.html
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/static/success.html
@@ -44,13 +44,13 @@
 
       // 서버로 결제 승인에 필요한 결제 정보를 보내세요.
       async function confirm() {
+        const paymentKey = urlParams.get("paymentKey");
         var requestData = {
-          paymentKey: urlParams.get("paymentKey"),
           orderId: urlParams.get("orderId"),
           amount: urlParams.get("amount"),
         };
 
-        const response = await fetch("http://localhost:8080/api/v1/payment/confirm", {
+        const response = await fetch(`http://localhost:8080/api/v1/payment/${paymentKey}/confirm`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
## 변경 사항
- 결제 승인 엔드포인트를 `/api/v1/payment/{paymentKey}/confirm` 으로 변경하여 REST 규약에 더 부합하도록함.
- `PaymentConfirmRequest` DTO은 `orderId`와 `amount` 값만 받도록 코드 변경
- `paymentKey`, `orderId`, `amount`를 가지는 `TossPaymentApproveRequest` 클래스를 생성
- 토스페이먼츠에 결제 승인 요청 전 PaymentConfirmRequest 대신 TossPaymentApproveRequest를 사용하도록 코드 수정 

--- 
Close: #11 