### PR TITLE
[FEATURE] 주문 상세 내역을 조회하는 기능 구현

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryController.java
@@ -32,7 +32,7 @@ public class OrderDetailQueryController {
         MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
         Long memberUid = memberDetail.getMember().getMemberUid();
 
-        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByOrderId(memberUid, orderId);
+        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId);
 
         OrderDetailResponse orderDetailResponse = OrderDetailResponse.builder()
                 .orderDetails(orderDetails)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryController.java
@@ -1,0 +1,46 @@
+package com.jamjam.bookjeok.domains.orderdetail.query.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.query.service.MemberQueryService;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
+import com.jamjam.bookjeok.domains.orderdetail.query.service.OrderDetailQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class OrderDetailQueryController {
+
+    private final MemberQueryService memberQueryService;
+    private final OrderDetailQueryService orderDetailQueryService;
+
+    @GetMapping("/members/{memberId}/orders/{orderId}/order-detail")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrderDetail(
+            @PathVariable(value = "memberId") String memberId,
+            @PathVariable(value = "orderId") String orderId
+    ) {
+        MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
+        Long memberUid = memberDetail.getMember().getMemberUid();
+
+        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByOrderId(memberUid, orderId);
+
+        OrderDetailResponse orderDetailResponse = OrderDetailResponse.builder()
+                .orderDetails(orderDetails)
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(orderDetailResponse));
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/dto/response/OrderDetailResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/dto/response/OrderDetailResponse.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.orderdetail.query.dto.response;
+
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OrderDetailResponse(
+    List<OrderDetailDTO> orderDetails
+) {
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/mapper/OrderDetailMapper.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/mapper/OrderDetailMapper.java
@@ -8,6 +8,6 @@ import java.util.List;
 @Mapper
 public interface OrderDetailMapper {
 
-    List<OrderDetailDTO> findOrderDetailByOrderId(Long memberUid, String orderId);
+    List<OrderDetailDTO> findOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/mapper/OrderDetailMapper.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/mapper/OrderDetailMapper.java
@@ -8,6 +8,6 @@ import java.util.List;
 @Mapper
 public interface OrderDetailMapper {
 
-    List<OrderDetailDTO> findOrderDetailByOrderId(String orderDetailId);
+    List<OrderDetailDTO> findOrderDetailByOrderId(Long memberUid, String orderId);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryService.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface OrderDetailQueryService {
 
-    List<OrderDetailDTO> getOrderDetailByOrderId(Long memberUid, String orderId);
+    List<OrderDetailDTO> getOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryService.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface OrderDetailQueryService {
 
-    List<OrderDetailDTO> findOrderDetailByOrderId(String orderId);
+    List<OrderDetailDTO> getOrderDetailByOrderId(Long memberUid, String orderId);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImpl.java
@@ -17,8 +17,8 @@ public class OrderDetailQueryServiceImpl implements OrderDetailQueryService {
     private final OrderDetailMapper orderDetailMapper;
 
     @Override
-    public List<OrderDetailDTO> findOrderDetailByOrderId(String orderId) {
-        List<OrderDetailDTO> orderDetails = orderDetailMapper.findOrderDetailByOrderId(orderId);
+    public List<OrderDetailDTO> getOrderDetailByOrderId(Long memberUid, String orderId) {
+        List<OrderDetailDTO> orderDetails = orderDetailMapper.findOrderDetailByOrderId(memberUid, orderId);
 
         if (orderDetails != null) {
             return orderDetails;

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImpl.java
@@ -17,8 +17,8 @@ public class OrderDetailQueryServiceImpl implements OrderDetailQueryService {
     private final OrderDetailMapper orderDetailMapper;
 
     @Override
-    public List<OrderDetailDTO> getOrderDetailByOrderId(Long memberUid, String orderId) {
-        List<OrderDetailDTO> orderDetails = orderDetailMapper.findOrderDetailByOrderId(memberUid, orderId);
+    public List<OrderDetailDTO> getOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId) {
+        List<OrderDetailDTO> orderDetails = orderDetailMapper.findOrderDetailByMemberUidAndOrderId(memberUid, orderId);
 
         if (orderDetails != null) {
             return orderDetails;

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
@@ -59,7 +59,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         savePayment(paymentDTO, savedOrder);
         pendingOrderService.deletePendingOrder(findPendingOrder.getOrderId());
 
-        List<OrderDetailDTO> orderDetails = orderDetailQueryService.findOrderDetailByOrderId(paymentDTO.orderId());
+        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByOrderId(savedOrder.getOrderUid(), paymentDTO.orderId());
 
         return PaymentConfirmResponse.builder()
                 .orderDetails(orderDetails)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
@@ -59,7 +59,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         savePayment(paymentDTO, savedOrder);
         pendingOrderService.deletePendingOrder(findPendingOrder.getOrderId());
 
-        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByOrderId(savedOrder.getMemberUid(), paymentDTO.orderId());
+        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(savedOrder.getMemberUid(), paymentDTO.orderId());
 
         return PaymentConfirmResponse.builder()
                 .orderDetails(orderDetails)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
@@ -59,7 +59,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         savePayment(paymentDTO, savedOrder);
         pendingOrderService.deletePendingOrder(findPendingOrder.getOrderId());
 
-        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByOrderId(savedOrder.getOrderUid(), paymentDTO.orderId());
+        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByOrderId(savedOrder.getMemberUid(), paymentDTO.orderId());
 
         return PaymentConfirmResponse.builder()
                 .orderDetails(orderDetails)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/orderdetail/OrderDetailMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/orderdetail/OrderDetailMapper.xml
@@ -9,6 +9,7 @@
         FROM order_details od
         JOIN orders o ON od.order_uid = o.order_uid
         JOIN books b ON od.book_id = b.book_id
-        WHERE o.order_id = #{ orderId }
+        WHERE o.member_uid = #{ memberUid }
+        AND o.order_id = #{ orderId }
     </select>
 </mapper>

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/orderdetail/OrderDetailMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/orderdetail/OrderDetailMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.jamjam.bookjeok.domains.orderdetail.query.mapper.OrderDetailMapper">
-    <select id="findOrderDetailByOrderId" resultType="com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO">
+    <select id="findOrderDetailByMemberUidAndOrderId" resultType="com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO">
         SELECT
             o.order_id, b.book_name, b.isbn, od.total_price,
             od.quantity, b.image_url, o.ordered_at

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryControllerTest.java
@@ -69,7 +69,7 @@ class OrderDetailQueryControllerTest {
                 .build();
 
         when(memberQueryService.getMemberDetail(memberId)).thenReturn(memberDetailResponse);
-        when(orderDetailQueryService.getOrderDetailByOrderId(memberUid, orderId)).thenReturn(orderDetails);
+        when(orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId)).thenReturn(orderDetails);
 
         mockMvc.perform(get("/api/v1/members/" + memberId + "/orders/" + orderId + "/order-detail")
                 .accept(MediaType.APPLICATION_JSON)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryControllerTest.java
@@ -1,0 +1,92 @@
+package com.jamjam.bookjeok.domains.orderdetail.query.controller;
+
+import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
+import com.jamjam.bookjeok.domains.member.query.service.MemberQueryServiceImpl;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.service.OrderDetailQueryServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrderDetailQueryController.class)
+@ImportAutoConfiguration(exclude = SecurityAutoConfiguration.class)
+class OrderDetailQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OrderDetailQueryServiceImpl orderDetailQueryService;
+
+    @MockBean
+    private MemberQueryServiceImpl memberQueryService;
+
+    private List<OrderDetailDTO> orderDetails;
+
+    @BeforeEach
+    void setUp() {
+        orderDetails = List.of(
+                OrderDetailDTO.builder()
+                        .orderId("ORD001")
+                        .bookName("책이름01")
+                        .isbn("9781082502299")
+                        .totalPrice(15000)
+                        .quantity(1)
+                        .imageUrl("http://localhost:8080/productimgs/604248.png")
+                        .orderedAt(LocalDateTime.now().withNano(0))
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("회원id와 주문id로 주문 상세 내역을 조회하는 테스트")
+    void testGetOrderDetail() throws Exception {
+        String memberId = "test01";
+        String orderId = "ORD001";
+        Long memberUid = 1L;
+
+        MemberDetailResponse memberDetailResponse = MemberDetailResponse.builder()
+                .member(new MemberDTO(memberUid, null, null, null,
+                        null, null, null, true,
+                        null, null, null, null))
+                .build();
+
+        when(memberQueryService.getMemberDetail(memberId)).thenReturn(memberDetailResponse);
+        when(orderDetailQueryService.getOrderDetailByOrderId(memberUid, orderId)).thenReturn(orderDetails);
+
+        mockMvc.perform(get("/api/v1/members/" + memberId + "/orders/" + orderId + "/order-detail")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.orderDetails").exists())
+                .andExpect(jsonPath("$.data.orderDetails").isArray())
+                .andExpect(jsonPath("$.data.orderDetails[0].orderId").value("ORD001"))
+                .andExpect(jsonPath("$.data.orderDetails[0].bookName").value("책이름01"))
+                .andExpect(jsonPath("$.data.orderDetails[0].isbn").value("9781082502299"))
+                .andExpect(jsonPath("$.data.orderDetails[0].totalPrice").value(15000))
+                .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
+                .andExpect(jsonPath("$.data.orderDetails[0].imageUrl").value("http://localhost:8080/productimgs/604248.png"))
+                .andExpect(jsonPath("$.data.orderDetails[0].orderedAt").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.jamjam.bookjeok.domains.orderdetail.query.service;
+
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.mapper.OrderDetailMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderDetailQueryServiceImplTest {
+
+    @InjectMocks
+    private OrderDetailQueryServiceImpl orderDetailQueryService;
+
+    @Mock
+    private OrderDetailMapper orderDetailMapper;
+
+    private List<OrderDetailDTO> orderDetails;
+
+    @BeforeEach
+    void setUp() {
+        orderDetails = List.of(
+                OrderDetailDTO.builder()
+                        .orderId("ORD001")
+                        .bookName("책이름01")
+                        .isbn("9781082502299")
+                        .totalPrice(15000)
+                        .quantity(1)
+                        .imageUrl("http://localhost:8080/productimgs/604248.png")
+                        .orderedAt(LocalDateTime.now().withNano(0))
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("회원Uid와 주문id로 주문 상세 내역을 조회하는 테스트")
+    void testGetOrderDetailByOrderId() {
+        Long memberUid = 1L;
+        String orderId = "ORD001";
+
+        when(orderDetailMapper.findOrderDetailByOrderId(memberUid, orderId)).thenReturn(orderDetails);
+
+        List<OrderDetailDTO> orderDetailsResult = orderDetailQueryService.getOrderDetailByOrderId(memberUid, orderId);
+
+        assertNotNull(orderDetailsResult);
+        assertThat(orderDetailsResult).hasSize(1);
+        assertThat(orderDetailsResult.get(0).orderId()).isEqualTo("ORD001");
+        assertThat(orderDetailsResult.get(0).bookName()).isEqualTo("책이름01");
+        assertThat(orderDetailsResult.get(0).isbn()).isEqualTo("9781082502299");
+        assertThat(orderDetailsResult.get(0).totalPrice()).isEqualTo(15000);
+        assertThat(orderDetailsResult.get(0).quantity()).isEqualTo(1);
+        assertThat(orderDetailsResult.get(0).imageUrl()).isEqualTo("http://localhost:8080/productimgs/604248.png");
+        assertThat(orderDetailsResult.get(0).orderedAt()).isNotNull();
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImplTest.java
@@ -45,13 +45,13 @@ class OrderDetailQueryServiceImplTest {
 
     @Test
     @DisplayName("회원Uid와 주문id로 주문 상세 내역을 조회하는 테스트")
-    void testGetOrderDetailByOrderId() {
+    void testGetOrderDetailByMemberUidAndOrderId() {
         Long memberUid = 1L;
         String orderId = "ORD001";
 
-        when(orderDetailMapper.findOrderDetailByOrderId(memberUid, orderId)).thenReturn(orderDetails);
+        when(orderDetailMapper.findOrderDetailByMemberUidAndOrderId(memberUid, orderId)).thenReturn(orderDetails);
 
-        List<OrderDetailDTO> orderDetailsResult = orderDetailQueryService.getOrderDetailByOrderId(memberUid, orderId);
+        List<OrderDetailDTO> orderDetailsResult = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId);
 
         assertNotNull(orderDetailsResult);
         assertThat(orderDetailsResult).hasSize(1);


### PR DESCRIPTION
## ✔️ 구현한 내용
- `OrderDetailQueryController` 구현
- `OrderDetailQueryService`에서 `memberUid`와 `orderId`로 주문 상세 내역을 조회하도록 기능을 수정
- `PaymentCommandServiceImpl`에 `memberUid`와 `orderId`로 주문 상세 내역을 조회하도록 코드를 수정
- `OrderDetailMapper`에도 `memberUid`와 `orderId`로 주문 상세 내역을 조회하도록 코드 수정
- 주문 상세 내역을 조회하는 service, mapper의 메서드명을 명확하게 변경
- `OrderDetailQueryServiceImpl` 테스트 코드를 작성
- `OrderDetailQueryController` 테스트 코드를 작성

--- 
Close: #17 