### PR TITLE
[REFACTOR] member 엔티티 패키지명 오류 수정

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/entity/Member.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/entity/Member.java
@@ -1,7 +1,5 @@
-package com.jamjam.bookjeok.domains.member.entity;
+package com.jamjam.bookjeok.domains.member.command.entity;
 
-import com.jamjam.bookjeok.domains.member.command.entity.MemberActivityStatus;
-import com.jamjam.bookjeok.domains.member.command.entity.MemberRole;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/MemberRepository.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/MemberRepository.java
@@ -2,12 +2,12 @@ package com.jamjam.bookjeok.domains.member.command.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
 
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<com.jamjam.bookjeok.domains.member.entity.Member, Long>{
+public interface MemberRepository extends JpaRepository<Member, Long>{
 
     Optional<Member> findByMemberId(String memberId);
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/FollowCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/FollowCommandServiceImpl.java
@@ -1,7 +1,7 @@
 package com.jamjam.bookjeok.domains.member.command.service;
 
 import com.jamjam.bookjeok.domains.member.command.entity.Follow;
-import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
 import com.jamjam.bookjeok.domains.member.command.repository.FollowRepository;
 import com.jamjam.bookjeok.domains.member.command.repository.MemberRepository;
 import com.jamjam.bookjeok.exception.member.MemberErrorCode;

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/MemberCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/MemberCommandServiceImpl.java
@@ -1,7 +1,7 @@
 package com.jamjam.bookjeok.domains.member.command.service;
 
 import com.jamjam.bookjeok.domains.member.command.dto.request.MemberCreateRequest;
-import com.jamjam.bookjeok.domains.member.entity.Member;
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
 import com.jamjam.bookjeok.domains.member.command.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;


### PR DESCRIPTION
- member 엔티티 패키지명 수정 : command 패키지에 하위에 있었으나 원래 패키지명에는 이 부분이 표시 되지 않았었음.
- member 엔티티를 사용하는 클래스에서 패키지명 수정된 버전으로 변경