### PR TITLE
[FEAT] 비밀번호 재설정 구현하기

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/build.gradle
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/build.gradle
@@ -88,6 +88,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+
+	// email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 dependencyManagement {

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/PasswordResetCommandController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/PasswordResetCommandController.java
@@ -1,0 +1,38 @@
+package com.jamjam.bookjeok.domains.member.command.controller;
+
+import com.jamjam.bookjeok.common.dto.ApiResponse;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordModifyRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordResetLinkRequest;
+import com.jamjam.bookjeok.domains.member.command.service.PasswordRestCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class PasswordResetCommandController {
+
+    private final PasswordRestCommandService passwordRestCommandService;
+
+    // 비밀번호 재설정 링크 요청
+    @PostMapping("/password/reset-link")
+    public ResponseEntity<ApiResponse<String>> requestReset(
+            @RequestBody PasswordResetLinkRequest passwordResetLinkRequest
+    ) {
+        String token = passwordRestCommandService.requestPasswordReset(passwordResetLinkRequest);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(token));
+    }
+
+    // 비밀번호 재설정 하기
+    @PostMapping("/password/reset")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody PasswordModifyRequest passwordModifyRequest) {
+        passwordRestCommandService.resetPassword(passwordModifyRequest);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/PasswordModifyRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/PasswordModifyRequest.java
@@ -1,0 +1,19 @@
+package com.jamjam.bookjeok.domains.member.command.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PasswordModifyRequest {
+
+    @NotNull(message = "토큰은 비어 있을 수 없습니다.")
+    private final String passwordResetToken;
+
+    @NotNull(message = "사용자의 비밀번호는 비어 있을 수 없습니다.")
+    @Pattern(regexp=".{8,}", message = "비밀번호는 최소 8자리 이상이어야 합니다.")
+    private final String newPassword;
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/PasswordModifyRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/PasswordModifyRequest.java
@@ -2,6 +2,7 @@ package com.jamjam.bookjeok.domains.member.command.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +14,7 @@ public class PasswordModifyRequest {
     private final String passwordResetToken;
 
     @NotNull(message = "사용자의 비밀번호는 비어 있을 수 없습니다.")
-    @Pattern(regexp=".{8,}", message = "비밀번호는 최소 8자리 이상이어야 합니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자리 이상이어야 합니다.")
     private final String newPassword;
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/PasswordResetLinkRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/PasswordResetLinkRequest.java
@@ -1,0 +1,14 @@
+package com.jamjam.bookjeok.domains.member.command.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PasswordResetLinkRequest {
+
+    @NotNull(message = "아이디는 비어 있을 수 없습니다.")
+    private final String memberId;
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/entity/PasswordResetToken.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/entity/PasswordResetToken.java
@@ -1,20 +1,14 @@
 package com.jamjam.bookjeok.domains.member.command.entity;
 
-
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "password_reset_token")
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PasswordResetToken {
 
     @Id
@@ -29,5 +23,12 @@ public class PasswordResetToken {
 
     @Column(nullable = false)
     private LocalDateTime expiryTime;
+
+    @Builder
+    public PasswordResetToken(String memberId, String resetToken, LocalDateTime expiryTime) {
+        this.memberId = memberId;
+        this.resetToken = resetToken;
+        this.expiryTime = expiryTime;
+    }
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/entity/PasswordResetToken.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/entity/PasswordResetToken.java
@@ -1,0 +1,33 @@
+package com.jamjam.bookjeok.domains.member.command.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "password_reset_token")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tokenId;
+
+    @Column(nullable = false)
+    private String memberId;
+
+    @Column(nullable = false)
+    private String resetToken;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryTime;
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/PasswordResetTokenRepository.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,10 @@
+package com.jamjam.bookjeok.domains.member.command.repository;
+
+import com.jamjam.bookjeok.domains.member.command.entity.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByResetToken (String resetToken);
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandService.java
@@ -1,0 +1,10 @@
+package com.jamjam.bookjeok.domains.member.command.service;
+
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
+import jakarta.mail.MessagingException;
+
+public interface EmailCommandService {
+    void sendPasswordResetEmail(Member member, String token) throws MessagingException;
+
+    void sendEmail(String to, String subject, String htmlContent) throws MessagingException;
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImpl.java
@@ -1,0 +1,71 @@
+package com.jamjam.bookjeok.domains.member.command.service;
+
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailCommandServiceImpl implements EmailCommandService {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendPasswordResetEmail(Member member, String token) throws MessagingException {
+        // 현재 시간
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        String formattedNow = now.format(formatter);
+
+        // 비밀번호 재설정 링크
+        // 이 부분은 프론트 설정하면서 변경할 예정
+        // 그리고 resetLink 앞에 부분도 변경 예정
+        String resetLink = "http://localhost:8000/bookjeok-service/api/v1/password/reset?token=" + token;
+
+        // 이메일 제목
+        String subject = "Book적Book적 비밀번호 재설정 메일";
+
+        // 받는 사람 이메일
+        String to = member.getEmail();
+
+        // 이메일 전체 구조 정의하는 틀
+        // 나중에 프론트 시작하면 분리할 예정
+        String htmlMsg =
+                "<div style='font-family: Arial, sans-serif; padding: 20px; background-color: #f4f4f4;'>"
+                + "  <div style='max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 30px; border-radius: 10px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);'>"
+                + "    <h2 style='color: #333;'>안녕하세요, Book적Book적입니다! 📚</h2>"
+                + "    <p style='font-size: 16px; color: #555;'>회원님은 <strong>" + formattedNow + "</strong>에 비밀번호 재설정을 요청하셨습니다.</p>"
+                + "    <p style='font-size: 16px; color: #555;'>아래 버튼을 클릭하셔서 비밀번호를 변경해주세요.</p>"
+                + "    <p style='font-size: 16px; color: #555;'>회원 아이디: <strong>" + member.getMemberId() + "</strong></p>"
+                + "    <div style='text-align: center; margin: 30px 0;'>"
+                + "      <a href='" + resetLink + "' style='display: inline-block; padding: 14px 24px; background-color: #1a73e8; color: white; text-decoration: none; font-weight: bold; border-radius: 6px;'>비밀번호 재설정 하기</a>"
+                + "    </div>"
+                + "  </div>"
+                + "</div>";
+
+        // 메일 전송 로직
+        sendEmail(to, subject, htmlMsg);
+    }
+
+    public void sendEmail(String to, String subject, String htmlContent) throws MessagingException {
+        // html 내용 전송을 도와주는 객체
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(to);
+        helper.setSubject(subject);
+        helper.setText(htmlContent, true);
+
+        mailSender.send(message);
+        log.info("이메일을 {}로 전송했습니다. 제목: {}", to, subject);
+    }
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/PasswordResetCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/PasswordResetCommandServiceImpl.java
@@ -1,0 +1,90 @@
+package com.jamjam.bookjeok.domains.member.command.service;
+
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordModifyRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordResetLinkRequest;
+import com.jamjam.bookjeok.domains.member.command.entity.PasswordResetToken;
+import com.jamjam.bookjeok.domains.member.command.repository.MemberRepository;
+import com.jamjam.bookjeok.domains.member.command.repository.PasswordResetTokenRepository;
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import com.jamjam.bookjeok.exception.member.passwordResetException.ExpiredTokenException;
+import com.jamjam.bookjeok.exception.member.passwordResetException.NotExistTokenException;
+import jakarta.mail.MessagingException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+/* 멤버가 모두 완성되면 멤버 서비스 쪽에 같이 합칠 예정 -> 비밀번호 재설정 서비스를 따로 분리할 필요가 없음*/
+public class PasswordResetCommandServiceImpl implements PasswordRestCommandService {
+
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final EmailCommandServiceImpl emailCommandService;
+
+    @Override
+    @Transactional
+    public String requestPasswordReset(PasswordResetLinkRequest passwordResetLinkRequest) {
+        // 멤버의 아이디로 멤버가 존재하는지 확인하기
+        String memberId = passwordResetLinkRequest.getMemberId();
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_EXIST_MEMBER));
+
+        // 토큰 생성하기 (토큰 생성은 나중에 따로 클래스를 분리)
+        String token = UUID.randomUUID().toString();
+        // 토큰 만료 시간은 30분으로 설정
+        LocalDateTime expirationTime = LocalDateTime.now().plusMinutes(30);
+        // 토큰 생성하기
+        PasswordResetToken passwordResetToken = PasswordResetToken.builder()
+                .memberId(memberId)
+                .resetToken(token)
+                .expiryTime(expirationTime)
+                .build();
+        // 토큰 저장하기
+        passwordResetTokenRepository.save(passwordResetToken);
+
+        try {
+            // 비밀번호 재설정 이메일 보내기 (토큰이 포함되어 있는 이메일이 발송 됨)
+            emailCommandService.sendPasswordResetEmail(member, token);
+        } catch (MessagingException e) {
+            throw new RuntimeException("이메일 전송 실패", e);
+        }
+
+        return token;
+    }
+
+    @Override
+    @Transactional
+    public void resetPassword(PasswordModifyRequest passwordModifyRequest) {
+        String token = passwordModifyRequest.getPasswordResetToken();
+        String newPassword = passwordModifyRequest.getNewPassword();
+
+        // 만약 토큰이 없다면
+        PasswordResetToken resetToken = passwordResetTokenRepository.findByResetToken(token)
+                .orElseThrow(() -> new NotExistTokenException(MemberErrorCode.NOT_EXIST_PASSWORD_RESET_TOKEN));
+
+        // 만약 토큰의 시간이 만료 됐다면
+        if (resetToken.getExpiryTime().isBefore(LocalDateTime.now())) {
+            throw new ExpiredTokenException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
+        }
+
+        // 멤버의 아이디로 멤버를 가져오기
+        Member member = memberRepository.findByMemberId(resetToken.getMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_EXIST_MEMBER));
+
+        // 비밀번호 변경하기
+        member.setEncodedPassword(passwordEncoder.encode(newPassword));
+
+        // 비밀번호 변경 직후 토큰 삭제하기
+        passwordResetTokenRepository.delete(resetToken);
+    }
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/PasswordRestCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/PasswordRestCommandService.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.member.command.service;
+
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordModifyRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordResetLinkRequest;
+
+public interface PasswordRestCommandService {
+
+    String requestPasswordReset(PasswordResetLinkRequest passwordResetLinkRequest);
+
+    void resetPassword(PasswordModifyRequest passwordModifyRequest);
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/MemberErrorCode.java
@@ -19,7 +19,9 @@ public enum MemberErrorCode {
     NOT_FOUND_BOOK("1008", "존재하지 않는 도서입니다.", HttpStatus.NOT_FOUND),
     INTEREST_BOOK_LIMIT_EXCEEDED("1009", "관심 도서는 최대 30권까지 등록할 수 있습니다.", HttpStatus.BAD_REQUEST),
     ALREADY_INTERESTED_BOOK("1010", "이미 관심 도서에 추가 됐습니다.", HttpStatus.CONFLICT),
-    NOT_REGIST_INTEREST_BOOK("1011", "관심 도서에 등록되어 있지 않습니다.", HttpStatus.BAD_REQUEST);
+    NOT_REGIST_INTEREST_BOOK("1011", "관심 도서에 등록되어 있지 않습니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_PASSWORD_RESET_TOKEN("1012", "존재하지 않는 토큰 입니다.", HttpStatus.NOT_FOUND),
+    EXPIRED_PASSWORD_RESET_TOKEN("1013", "기간이 만료된 토큰 입니다.", HttpStatus.GONE);
 
     private final String code;
     private final String message;

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/MemberExceptionHandler.java
@@ -9,6 +9,8 @@ import com.jamjam.bookjeok.exception.member.interestAuthorException.InterestAuth
 import com.jamjam.bookjeok.exception.member.interestBookException.AlreadyInterestedBookException;
 import com.jamjam.bookjeok.exception.member.interestBookException.InterestBookLimitExceededException;
 import com.jamjam.bookjeok.exception.member.interestBookException.NotFoundBookException;
+import com.jamjam.bookjeok.exception.member.passwordResetException.ExpiredTokenException;
+import com.jamjam.bookjeok.exception.member.passwordResetException.NotExistTokenException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -103,4 +105,26 @@ public class MemberExceptionHandler {
 
         return new ResponseEntity<>(response,errorCode.getHttpStatus());
     }
+
+    @ExceptionHandler(NotExistTokenException.class)
+    public ResponseEntity<ApiResponse> handleNotExistTokenException(NotExistTokenException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(ExpiredTokenException.class)
+    public ResponseEntity<ApiResponse> handleExpiredTokenException(ExpiredTokenException e){
+        MemberErrorCode errorCode = e.getMemberErrorCode();
+
+        ApiResponse<Void> response
+                = ApiResponse.failure(errorCode.getCode(), errorCode.getMessage());
+
+        return new ResponseEntity<>(response,errorCode.getHttpStatus());
+    }
+
+
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/passwordResetException/ExpiredTokenException.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/passwordResetException/ExpiredTokenException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.passwordResetException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ExpiredTokenException extends RuntimeException {
+
+    private final MemberErrorCode memberErrorCode;
+
+    public ExpiredTokenException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/passwordResetException/NotExistTokenException.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/exception/member/passwordResetException/NotExistTokenException.java
@@ -1,0 +1,15 @@
+package com.jamjam.bookjeok.exception.member.passwordResetException;
+
+import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotExistTokenException extends RuntimeException {
+
+    private final MemberErrorCode memberErrorCode;
+
+    public NotExistTokenException(MemberErrorCode memberErrorCode) {
+        super(memberErrorCode.getMessage());
+        this.memberErrorCode = memberErrorCode;
+    }
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/application.yml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/application.yml
@@ -29,6 +29,18 @@ spring:
         format_sql: true
         use_sql_comments: true
 
+  mail:
+    host: ${SPRING_MAIL_HOST}
+    port: ${SPRING_MAIL_PORT}
+    username: ${SPRING_MAIL_USERNAME}
+    password: ${SPRING_MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 mybatis:
   configuration:
     map-underscore-to-camel-case: true

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/PasswordResetCommandControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/PasswordResetCommandControllerTest.java
@@ -1,0 +1,64 @@
+package com.jamjam.bookjeok.domains.member.command.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordModifyRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordResetLinkRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class PasswordResetCommandControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+
+    @DisplayName("비밀번호 재설정 링크 요청 테스트")
+    @Test
+    void requestResetTest() throws Exception {
+        String memberId = "user01";
+
+        PasswordResetLinkRequest request = new PasswordResetLinkRequest(memberId);
+
+        mockMvc.perform(post("/api/v1/password/reset-link")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+    }
+
+    @DisplayName("비밀번호 재설정 테스트")
+    @Test
+    void resetPasswordTest() throws Exception {
+        String token = "testToken";
+        String newPassword = "newPassword";
+
+        PasswordModifyRequest passwordModifyRequest = new PasswordModifyRequest(token, newPassword);
+
+        mockMvc.perform(post("/api/v1/password/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(passwordModifyRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andReturn();
+    }
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImplTest.java
@@ -1,0 +1,31 @@
+package com.jamjam.bookjeok.domains.member.command.service;
+
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class EmailCommandServiceImplTest {
+
+    @Autowired
+    private EmailCommandService emailCommandService;
+
+    @DisplayName("비밀번호 재설정 이메일 보내기 테스트")
+    @Test
+    void sendPasswordResetEmailTest() throws Exception {
+        Member member = Member.builder()
+                .email("bookjeok@bookjeok.com")
+                .memberId("jamjam123")
+                .build();
+
+        String token = "mock-token-123";
+
+        emailCommandService.sendPasswordResetEmail(member, token);
+    }
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/PasswordResetServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/PasswordResetServiceImplTest.java
@@ -1,0 +1,150 @@
+package com.jamjam.bookjeok.domains.member.command.service;
+
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordModifyRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PasswordResetLinkRequest;
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
+import com.jamjam.bookjeok.domains.member.command.entity.PasswordResetToken;
+import com.jamjam.bookjeok.domains.member.command.repository.MemberRepository;
+import com.jamjam.bookjeok.domains.member.command.repository.PasswordResetTokenRepository;
+import com.jamjam.bookjeok.exception.member.MemberException;
+import com.jamjam.bookjeok.exception.member.passwordResetException.ExpiredTokenException;
+import com.jamjam.bookjeok.exception.member.passwordResetException.NotExistTokenException;
+import jakarta.mail.MessagingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/* Mock 객체를 이용해서 서비스 단위 테스트 진행*/
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceImplTest {
+
+    @Mock
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private EmailCommandServiceImpl emailService;
+
+    @InjectMocks
+    private PasswordResetCommandServiceImpl passwordResetService;
+
+
+    @DisplayName("비밀번호 변경 요청하기")
+    @Test
+    void requestPasswordResetTest () throws MessagingException {
+        String memberId = "user01";
+        PasswordResetLinkRequest request = new PasswordResetLinkRequest(memberId);
+
+        Member member = Member.builder()
+                .memberId(memberId)
+                .email("book123@gmail.com")
+                .build();
+
+        when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.of(member));
+        // 이메일 전송 부분은 진행하지 않고 넘어가기
+        doNothing().when(emailService).sendPasswordResetEmail(any(), any());
+
+        String result = passwordResetService.requestPasswordReset(request);
+
+        // then
+        assertNotNull(result);
+        verify(memberRepository).findByMemberId(memberId);
+    }
+
+    @DisplayName("비밀번호 변경 요청 시 회원이 없는 경우 발생하는 예외")
+    @Test
+    void setPasswordResetServiceMemberExceptionTest () {
+        String memberId = "user01";
+        PasswordResetLinkRequest request = new PasswordResetLinkRequest(memberId);
+
+        when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+        assertThrows(MemberException.class,
+                () -> passwordResetService.requestPasswordReset(request));
+    }
+
+    @DisplayName("비밀번호 재설정을 링크를 통한 비밀번호 변경 테스트")
+    @Test
+    void resetPasswordTest() {
+        String token = "abc123";
+        String newPassword = "newPassword";
+        String encodedPassword = "encodePassword";
+
+        PasswordModifyRequest request = new PasswordModifyRequest(token, newPassword);
+
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .memberId("user01")
+                .resetToken(token)
+                .expiryTime(LocalDateTime.now().plusMinutes(10))
+                .build();
+
+        Member member = Member.builder()
+                .memberId("user01")
+                .password("old_pw")
+                .build();
+
+        when(passwordResetTokenRepository.findByResetToken(token)).thenReturn(Optional.of(resetToken));
+        when(memberRepository.findByMemberId("user01")).thenReturn(Optional.of(member));
+        when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
+
+        passwordResetService.resetPassword(request);
+
+        assertEquals(encodedPassword, member.getPassword());
+
+        // 토큰을 삭제하는 동작이 발생했는지 확인
+        verify(passwordResetTokenRepository).delete(resetToken);
+    }
+
+    // 없는 토큰인 경우
+    @DisplayName("토큰이 없는 경우 발생하는 예외")
+    @Test
+    void notExistTokenExceptionTest() {
+        String invalidToken = "invalidToken";
+        PasswordModifyRequest request = new PasswordModifyRequest(invalidToken, "newPassword");
+
+        when(passwordResetTokenRepository.findByResetToken(invalidToken))
+                .thenReturn(Optional.empty());
+
+        assertThrows(NotExistTokenException.class, () -> {
+            passwordResetService.resetPassword(request);
+        });
+    }
+
+
+    // 유효 시간이 지난 토큰인 경우
+    @DisplayName("유효 시간이 지난 토큰인 경우 발생하는 예외")
+    @Test
+    void expiryTimeExceptionTest() {
+        String expiredToken = "expiredToken";
+        PasswordModifyRequest request = new PasswordModifyRequest(expiredToken, "newPassword");
+
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .memberId("user01")
+                .resetToken(expiredToken)
+                .expiryTime(LocalDateTime.now().minusMinutes(1))
+                .build();
+
+        when(passwordResetTokenRepository.findByResetToken(expiredToken))
+                .thenReturn(Optional.of(resetToken));
+
+        assertThrows(ExpiredTokenException.class, () -> {
+            passwordResetService.resetPassword(request);
+        });
+    }
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/resources/application-test.yml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/resources/application-test.yml
@@ -20,6 +20,18 @@ spring:
         format_sql: true
         use_sql_comments: true
 
+  mail:
+    host: ${SPRING_MAIL_HOST}
+    port: ${SPRING_MAIL_PORT}
+    username: ${SPRING_MAIL_USERNAME}
+    password: ${SPRING_MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 mybatis:
   configuration:
     map-underscore-to-camel-case: true


### PR DESCRIPTION
 ## ⭐기능 내용
비밀번호를 잊어버린 경우 이메일로 비밀번호 재설정 링크를 받아 비밀번호를 수정하는 기능

## ✅구현 기능
- PasswordResetCommandController
  - 비밀번호 재설정 링크 요청
  - 비밀번호 재설정 요청 
  - PasswordResetCommandController 테스트 완료
- PasswordResetCommandService
  - 비밀번호 재설정 서비스 구현
  - 비밀번호 재설정 요청 시 토큰 생성 후 비밀번호 재설정 이메일 보내기
  - 비밀번호 변경하기
  - PasswordResetCommandService 테스트 완료
- EmailCommandService
  - 이메일 발송 서비스 구현 
  - 이메일을 발송하는 메소드와 비밀먼호 변경 메일 발송 메소드 구현  
  - EmailCommandService 테스트 완료
- passwordResetException
  - NotExistTokenException : 토큰이 존재하지 않는 경우 발생하는 예외 생성
  - ExpiredTokenException : 토큰이 만료된 경우 발생하는 예외 생성
  - ErrorCode 작성 및 MemberExceptionHandler 처리