### PR TITLE
[FEATURE] 멤버 전체 목록 조회 기능 수정 및 멤버 아이디로 멤버 조회하기 기능 추가

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/MemberSearchRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/MemberSearchRequest.java
@@ -1,13 +1,32 @@
 package com.jamjam.bookjeok.domains.member.command.dto.request;
 
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class MemberSearchRequest {
+    @Min(1)
+    private Integer page;
+
+    @Min(1)
+    private Integer size;
 
     private String memberId;
+
     private String nickname;
 
+    public MemberSearchRequest(Integer page, Integer size, String memberId, String nickname) {
+        this.page = (page != null) ? page : 1;
+        this.size = (size != null) ? size : 10;
+        this.memberId = memberId;
+        this.nickname = nickname;
+    }
+
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+
+    public int getLimit() {
+        return size;
+    }
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/response/MemberDetailResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/response/MemberDetailResponse.java
@@ -1,7 +1,8 @@
 package com.jamjam.bookjeok.domains.member.command.dto.response;
 
 import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @Builder

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/AdminQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/AdminQueryController.java
@@ -37,7 +37,7 @@ public class AdminQueryController {
     }
 
 //    @PreAuthorize("hasAuthority('ADMIN')")
-    @GetMapping("/admin/member/{memberId}")
+    @GetMapping("/admin/members/{memberId}")
     public ResponseEntity<ApiResponse<MemberDetailResponse>> getMemberByMemberId(
             @PathVariable String memberId
     ){

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/AdminQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/AdminQueryController.java
@@ -7,12 +7,14 @@ import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberListResponse;
 import com.jamjam.bookjeok.domains.member.query.service.AdminQueryService;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,26 +26,22 @@ public class AdminQueryController {
 
     private final AdminQueryService adminQueryService;
 
-    @PreAuthorize("hasAuthority('ADMIN')")
+//    @PreAuthorize("hasAuthority('ADMIN')")
     @GetMapping("/admin/members")
     public ResponseEntity<ApiResponse<MemberListResponse>> getAllMembers(
-            @Validated PageRequest pageRequest
+            MemberSearchRequest memberSearchRequest
     ){
-        MemberListResponse response = adminQueryService.getAllMembers(pageRequest);
+        MemberListResponse response = adminQueryService.getAllMembers(memberSearchRequest);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PreAuthorize("hasAuthority('ADMIN')")
-    @GetMapping("/admin/member")
-    public ResponseEntity<ApiResponse<MemberDetailResponse>> getMemberByName(
-            MemberSearchRequest memberSearchRequest
+//    @PreAuthorize("hasAuthority('ADMIN')")
+    @GetMapping("/admin/member/{memberId}")
+    public ResponseEntity<ApiResponse<MemberDetailResponse>> getMemberByMemberId(
+            @PathVariable String memberId
     ){
-
-        MemberDetailResponse response = adminQueryService.getMemberByIdOrNickname(memberSearchRequest);
-
-        log.info("멤버의 아이디 = " + response.getMember().getMemberId());
-        log.info("멤버의 닉네임 = " + response.getMember().getNickname());
+        MemberDetailResponse response = adminQueryService.getMemberByMemberId(memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/mapper/AdminMapper.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/mapper/AdminMapper.java
@@ -6,14 +6,14 @@ import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface AdminMapper {
 
-    List<MemberDTO> findAllMember(PageRequest pageRequest);
+    List<MemberDTO> findAllMember(MemberSearchRequest memberSearchRequest);
 
-    long countMembers();
+    long countMembers(MemberSearchRequest memberSearchRequest);
 
-    MemberDTO findMemberByIdOrNickname(MemberSearchRequest memberSearchRequest);
-
+    MemberDTO findMemberByMemberId(String memberId);
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/AdminQueryService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/AdminQueryService.java
@@ -1,12 +1,11 @@
 package com.jamjam.bookjeok.domains.member.query.service;
 
 import com.jamjam.bookjeok.domains.member.command.dto.request.MemberSearchRequest;
-import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberListResponse;
 
 public interface AdminQueryService {
-    MemberListResponse getAllMembers(PageRequest pageRequest);
+    MemberListResponse getAllMembers(MemberSearchRequest memberSearchRequest);
 
-    MemberDetailResponse getMemberByIdOrNickname(MemberSearchRequest memberSearchRequest);
+    MemberDetailResponse getMemberByMemberId(String memberId);
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/AdminQueryServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/AdminQueryServiceImpl.java
@@ -3,7 +3,6 @@ package com.jamjam.bookjeok.domains.member.query.service;
 import com.jamjam.bookjeok.common.dto.Pagination;
 import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
 import com.jamjam.bookjeok.domains.member.command.dto.request.MemberSearchRequest;
-import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberListResponse;
 import com.jamjam.bookjeok.domains.member.query.mapper.AdminMapper;
@@ -25,14 +24,14 @@ public class AdminQueryServiceImpl implements AdminQueryService {
     // 멤버의 전체 목록을 조회하는 기능
     @Override
     @Transactional(readOnly = true)
-    public MemberListResponse getAllMembers(PageRequest pageRequest) {
-        List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
+    public MemberListResponse getAllMembers(MemberSearchRequest memberSearchRequest) {
+        List<MemberDTO> members = adminMapper.findAllMember(memberSearchRequest);
 
         // 페이징 처리를 위해 전체 멤버의 수 조회하기
-        long totalItems = adminMapper.countMembers();
+        long totalItems = adminMapper.countMembers(memberSearchRequest);
 
-        int page = pageRequest.getPage();
-        int size = pageRequest.getSize();
+        int page = memberSearchRequest.getPage();
+        int size = memberSearchRequest.getSize();
 
         return MemberListResponse.builder()
                 .memberList(members)
@@ -46,16 +45,11 @@ public class AdminQueryServiceImpl implements AdminQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public MemberDetailResponse getMemberByIdOrNickname(MemberSearchRequest memberSearchRequest){
+    public MemberDetailResponse getMemberByMemberId(String memberId){
+
         MemberDTO member = Optional.ofNullable(
-                adminMapper.findMemberByIdOrNickname(memberSearchRequest)
+                adminMapper.findMemberByMemberId(memberId)
         ).orElseThrow(() -> new MemberException(MemberErrorCode.NOT_EXIST_MEMBER));
-
-
-        if ((memberSearchRequest.getMemberId() == null || memberSearchRequest.getMemberId().isBlank()) &&
-                (memberSearchRequest.getNickname() == null || memberSearchRequest.getNickname().isBlank())) {
-            throw new MemberException(MemberErrorCode.MEMBER_SEARCH_CONDITION_MISSING);
-        }
 
         return MemberDetailResponse.builder()
                 .member(member)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/AdminMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/AdminMapper.xml
@@ -17,6 +17,14 @@
             activity_status
         FROM members
         WHERE role = 'MEMBER'
+        <choose>
+            <when test="memberId != null and memberId != ''">
+                AND member_id = #{ memberId }
+            </when>
+            <when test="nickname != null and nickname != ''">
+                AND nickname = #{ nickname }
+            </when>
+        </choose>
         ORDER BY member_uid
         LIMIT #{ limit } OFFSET #{ offset }
     </select>
@@ -25,9 +33,17 @@
         SELECT COUNT(*)
         FROM members
         WHERE role = 'MEMBER'
+        <choose>
+            <when test="memberId != null and memberId != ''">
+                AND member_id = #{ memberId }
+            </when>
+            <when test="nickname != null and nickname != ''">
+                AND nickname = #{ nickname }
+            </when>
+        </choose>
     </select>
 
-    <select id="findMemberByIdOrNickname" resultType="MemberDTO">
+    <select id="findMemberByMemberId" resultType="MemberDTO">
     SELECT
         member_uid,
         member_id,
@@ -40,15 +56,7 @@
         activity_status
     FROM members
     WHERE role = 'MEMBER'
-    <choose>
-        <when test="memberId != null and memberId != ''">
-            AND member_id = #{ memberId }
-        </when>
-        <when test="nickname != null and nickname != ''">
-            AND nickname = #{ nickname }
-        </when>
-    </choose>
-    ORDER BY member_uid;
+    AND member_id = #{ memberId }
     </select>
 
 </mapper>

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/AdminQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/AdminQueryControllerTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -39,39 +38,63 @@ class AdminQueryControllerTest {
                 .andDo(print());
     }
 
-    @DisplayName("멤버의 아이디로 멤버를 검색하는 테스트")
+    @DisplayName("전체 멤버에서 멤버의 아이디로 멤버를 검색하는 테스트")
     @WithMockUser(authorities = "ADMIN")
     @Test
     void getMemberByIdTest() throws Exception {
         String memberId = "user02";
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/member")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/members")
                         .param("memberId", memberId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.timestamp").exists())
-                .andExpect(jsonPath("$.data.member.memberId").value("user02"))
-                .andExpect(jsonPath("$.data.member.memberName").value("유형진"))
-                .andExpect(jsonPath("$.data.member.phoneNumber").value("01024001349"))
-                .andExpect(jsonPath("$.data.member.email").value("test2@gmail.com"))
-                .andExpect(jsonPath("$.data.member.nickname").value("닉네임02"))
-                .andExpect(jsonPath("$.data.member.marketingConsent").value(true))
-                .andExpect(jsonPath("$.data.member.createdAt").value("2025-02-06T14:13:32"))
-                .andExpect(jsonPath("$.data.member.activityStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.memberList[0].memberId").value("user02"))
+                .andExpect(jsonPath("$.data.memberList[0].memberName").value("유형진"))
+                .andExpect(jsonPath("$.data.memberList[0].phoneNumber").value("01024001349"))
+                .andExpect(jsonPath("$.data.memberList[0].email").value("test2@gmail.com"))
+                .andExpect(jsonPath("$.data.memberList[0].nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data.memberList[0].marketingConsent").value(true))
+                .andExpect(jsonPath("$.data.memberList[0].createdAt").value("2025-02-06T14:13:32"))
+                .andExpect(jsonPath("$.data.memberList[0].activityStatus").value("ACTIVE"))
                 .andDo(print());
     }
 
-    @DisplayName("멤버의 닉네임으로 멤버를 검색하는 테스트")
+    @DisplayName("전체 멤버에서 멤버의 닉네임으로 멤버를 검색하는 테스트")
     @WithMockUser(authorities = "ADMIN")
     @Test
     void getMemberByNicknameTest() throws Exception {
         String nickname = "닉네임02";
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/member")
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/members")
                         .param("nickname", nickname))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.data.memberList[0].memberUid").value(2))
+                .andExpect(jsonPath("$.data.memberList[0].memberId").value("user02"))
+                .andExpect(jsonPath("$.data.memberList[0].memberName").value("유형진"))
+                .andExpect(jsonPath("$.data.memberList[0].phoneNumber").value("01024001349"))
+                .andExpect(jsonPath("$.data.memberList[0].email").value("test2@gmail.com"))
+                .andExpect(jsonPath("$.data.memberList[0].nickname").value("닉네임02"))
+                .andExpect(jsonPath("$.data.memberList[0].marketingConsent").value(true))
+                .andExpect(jsonPath("$.data.memberList[0].createdAt").value("2025-02-06T14:13:32"))
+                .andExpect(jsonPath("$.data.memberList[0].activityStatus").value("ACTIVE"))
+                .andDo(print());
+    }
+
+
+    @DisplayName("멤버의 아이디로 특정 회원을 조회하는 테스트")
+    @WithMockUser(authorities = "ADMIN")
+    @Test
+    void getMemberByMemberId() throws Exception {
+        String memberId = "user02";
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/admin/member/{memberId}", memberId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.data.member.memberUid").value(2))
                 .andExpect(jsonPath("$.data.member.memberId").value("user02"))
                 .andExpect(jsonPath("$.data.member.memberName").value("유형진"))
                 .andExpect(jsonPath("$.data.member.phoneNumber").value("01024001349"))
@@ -82,5 +105,6 @@ class AdminQueryControllerTest {
                 .andExpect(jsonPath("$.data.member.activityStatus").value("ACTIVE"))
                 .andDo(print());
     }
+
 }
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/mapper/AdminMapperTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/mapper/AdminMapperTest.java
@@ -1,7 +1,6 @@
 package com.jamjam.bookjeok.domains.member.query.mapper;
 
 import com.jamjam.bookjeok.domains.member.command.dto.request.MemberSearchRequest;
-import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,8 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -21,14 +19,14 @@ class AdminMapperTest {
     @Autowired
     private AdminMapper adminMapper;
 
-    private PageRequest pageRequest;
+    private MemberSearchRequest memberSearchRequest;
 
     @DisplayName("findAllMember 테스트")
     @Test
     void findAllMemberTest(){
-        pageRequest = new PageRequest(1,10);
+        memberSearchRequest = new MemberSearchRequest(1, 10, null, null);
 
-        List<MemberDTO> members = adminMapper.findAllMember(pageRequest);
+        List<MemberDTO> members = adminMapper.findAllMember(memberSearchRequest);
 
         assertNotNull(members);
         members.forEach(System.out::println);
@@ -37,7 +35,9 @@ class AdminMapperTest {
     @DisplayName("전체 멤버 인원 조회 테스트")
     @Test
     void countAllMember(){
-        long count = adminMapper.countMembers();
+        memberSearchRequest = new MemberSearchRequest(1, 10, null, null);
+
+        long count = adminMapper.countMembers(memberSearchRequest);
         assertEquals(7, count);
     }
 
@@ -47,11 +47,10 @@ class AdminMapperTest {
     void selectMemberByIdTest(){
         String memberId = "user02";
 
-        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(memberId,null);
-        MemberDTO member
-                = adminMapper.findMemberByIdOrNickname(memberSearchRequest);
+        memberSearchRequest = new MemberSearchRequest(1, 10, memberId, null);
+        List<MemberDTO> member = adminMapper.findAllMember(memberSearchRequest);
 
-        assertEquals("유형진", member.getMemberName());
+        assertEquals("닉네임02", member.get(0).getNickname());
     }
 
     @DisplayName("멤버의 닉네임으로 멤버를 검색하는 테스트")
@@ -59,10 +58,19 @@ class AdminMapperTest {
     void selectMemberByNicknameTest(){
         String nickname = "닉네임02";
 
-        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(null,nickname);
-        MemberDTO member
-                = adminMapper.findMemberByIdOrNickname(memberSearchRequest);
+        memberSearchRequest = new MemberSearchRequest(1, 10, null, nickname);
+        List<MemberDTO> member = adminMapper.findAllMember(memberSearchRequest);
 
-        assertEquals("유형진", member.getMemberName());
+        assertEquals("유형진", member.get(0).getMemberName());
+    }
+
+    @DisplayName("멤버의 아이디로 멤버를 조회하는 테스트")
+    @Test
+    void selectMemberByMemberIdTest(){
+        String memberId = "user02";
+
+        MemberDTO member = adminMapper.findMemberByMemberId(memberId);
+
+        assertEquals("닉네임02", member.getNickname());
     }
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/service/AdminServiceTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/service/AdminServiceTest.java
@@ -1,10 +1,7 @@
 package com.jamjam.bookjeok.domains.member.query.service;
 
 import com.jamjam.bookjeok.domains.member.command.dto.request.MemberSearchRequest;
-import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
-import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberListResponse;
-import com.jamjam.bookjeok.domains.member.command.entity.MemberRole;
 import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
 import com.jamjam.bookjeok.domains.member.query.mapper.AdminMapper;
 import com.jamjam.bookjeok.exception.member.MemberException;
@@ -37,7 +34,7 @@ class AdminServiceTest {
     @DisplayName("findAllMember 서비스 단위 테스트")
     @Test
     void getAllMemberTest() {
-        PageRequest request = new PageRequest(1, 10);
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(1, 10, null, null);
 
         MemberDTO member1 = MemberDTO.builder()
                 .memberUid(1L)
@@ -51,24 +48,24 @@ class AdminServiceTest {
                 .activityStatus("ACTIVE")
                 .build();
 
-    MemberDTO member2 = MemberDTO.builder()
-            .memberUid(2L)
-            .memberId("user02")
-            .memberName("유형진")
-            .phoneNumber("01024001349")
-            .email("test2@gmail.com")
-            .nickname("닉네임02")
-            .marketingConsent(true)
-            .createdAt(LocalDateTime.of(2025, 2, 6, 14, 13, 32))
-            .activityStatus("DEACTIVATE")
-            .build();
+        MemberDTO member2 = MemberDTO.builder()
+                .memberUid(2L)
+                .memberId("user02")
+                .memberName("유형진")
+                .phoneNumber("01024001349")
+                .email("test2@gmail.com")
+                .nickname("닉네임02")
+                .marketingConsent(true)
+                .createdAt(LocalDateTime.of(2025, 2, 6, 14, 13, 32))
+                .activityStatus("DEACTIVATE")
+                .build();
 
         List<MemberDTO> fakeMembers = Arrays.asList(member1, member2);
 
-        when(adminMapper.findAllMember(request)).thenReturn(fakeMembers);
-        when(adminMapper.countMembers()).thenReturn(2L);
+        when(adminMapper.findAllMember(memberSearchRequest)).thenReturn(fakeMembers);
+        when(adminMapper.countMembers(memberSearchRequest)).thenReturn(2L);
 
-        MemberListResponse response = adminQueryService.getAllMembers(request);
+        MemberListResponse response = adminQueryService.getAllMembers(memberSearchRequest);
 
         assertNotNull(response);
         assertEquals(2, response.getMemberList().size());
@@ -77,7 +74,8 @@ class AdminServiceTest {
     @DisplayName("getMemberById 서비스 단위 테스트")
     @Test
     void getMemberByIdTest() {
-        MemberSearchRequest searchRequest = new MemberSearchRequest("user02", null);
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(1, 10, "user02", null);
+
         MemberDTO member = MemberDTO.builder()
                 .memberUid(1L)
                 .memberId("user01")
@@ -90,19 +88,20 @@ class AdminServiceTest {
                 .activityStatus("ACTIVE")
                 .build();
 
+        List<MemberDTO> fakeMembers = Arrays.asList(member);
 
-        when(adminMapper.findMemberByIdOrNickname(searchRequest)).thenReturn(member);
+        when(adminMapper.findAllMember(memberSearchRequest)).thenReturn(fakeMembers);
 
-        MemberDetailResponse result = adminQueryService.getMemberByIdOrNickname(searchRequest);
+        MemberListResponse result = adminQueryService.getAllMembers(memberSearchRequest);
 
         assertNotNull(result);
-        assertEquals("홍길동", result.getMember().getMemberName());
+        assertEquals("닉네임01", result.getMemberList().get(0).getNickname());
     }
 
     @DisplayName("getMemberByNickname 서비스 단위 테스트")
     @Test
     void getMemberByIdOrNicknameTest() {
-        MemberSearchRequest searchRequest = new MemberSearchRequest(null, "닉네임01");
+        MemberSearchRequest memberSearchRequest = new MemberSearchRequest(1, 10, null, "닉네임01");
         MemberDTO member = MemberDTO.builder()
                 .memberUid(1L)
                 .memberId("user01")
@@ -115,33 +114,24 @@ class AdminServiceTest {
                 .activityStatus("ACTIVE")
                 .build();
 
-        when(adminMapper.findMemberByIdOrNickname(searchRequest)).thenReturn(member);
+        List<MemberDTO> fakeMembers = Arrays.asList(member);
 
-        MemberDetailResponse result = adminQueryService.getMemberByIdOrNickname(searchRequest);
+        when(adminMapper.findAllMember(memberSearchRequest)).thenReturn(fakeMembers);
+
+        MemberListResponse result = adminQueryService.getAllMembers(memberSearchRequest);
 
         assertNotNull(result);
-        assertEquals("닉네임01", result.getMember().getNickname());
+        assertEquals("홍길동", result.getMemberList().get(0).getMemberName());
     }
 
-    @DisplayName("아무것도 검색하지 않는 경우에 exception 발생")
+    @DisplayName("회원이 없는 경우 exception 발생")
     @Test
     void getMemberByIdOrNicknameExceptionTest() {
-        MemberSearchRequest searchRequest = new MemberSearchRequest(null, null);
-        MemberDTO member = MemberDTO.builder()
-                .memberUid(1L)
-                .memberId("user01")
-                .memberName("홍길동")
-                .phoneNumber("01012345678")
-                .email("test1@gmail.com")
-                .nickname("닉네임01")
-                .marketingConsent(true)
-                .createdAt(LocalDateTime.of(2025, 4, 6, 11, 13, 40))
-                .activityStatus("ACTIVE")
-                .build();
+        String memberId = "fakeId";
 
-        when(adminMapper.findMemberByIdOrNickname(searchRequest)).thenReturn(member);
+        when(adminMapper.findMemberByMemberId(memberId)).thenReturn(null);
 
         assertThrows(MemberException.class,
-                () -> adminQueryService.getMemberByIdOrNickname(searchRequest));
+                () -> adminQueryService.getMemberByMemberId(memberId));
     }
 }


### PR DESCRIPTION
## ⭐ 기능 설명
멤버 전체 목록 조회 기능 수정 및 멤버 아이디로 멤버 조회하기 기능 추가 (Close #35)

## ✅ 상세 설명
- MemberSearchRequest에 페이지 처리와 검색을 위해 사용하는 memberId와 nickname을 받아옴
- AdminQueryController
  - 프론트와의 테스트를 위해 권환 관련 설정 주석처리
  - 멤버 목록 조회에서 매개변수를 MemberSearchRequest로 수정
  - 특정 멤버의 정보를 받아오는 부분 경로 수정
- AdminMapper.java
  - countMembers와 findAllMembers에 MemberSearchRequest를 매개변수로 추가
  - findMemberByMemberId로 메소드명 수정
- AdminMapper.xml
  - findAllMember와 countMembers에 검색 조건 추가
  - 메소드명을 findMemberByMemberId로 수정
- AdminQueryService & AdminQueryServiceImpl
 - getAllMembers에서 매개변수 수정
 - getMemberByMemberId로 메소드명 수정 및 매개변수 수정
- AdminMapper 테스트 수정
- AdminService 테스트 수정
- AdminController 테스트 수정

