### PR TITLE
[FEATURE] 관심 작가 페이지 구현을 위한 코드 수정 및 추가

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/response/InterestAuthorListResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/response/InterestAuthorListResponse.java
@@ -1,0 +1,18 @@
+package com.jamjam.bookjeok.domains.member.command.dto.response;
+
+import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
+import com.jamjam.bookjeok.domains.member.query.dto.InterestBookDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class InterestAuthorListResponse {
+
+    private List<InterestAuthorDTO> interestAuthorList;
+    private final Pagination pagination;
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/InterestAuthorQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/InterestAuthorQueryController.java
@@ -1,13 +1,13 @@
 package com.jamjam.bookjeok.domains.member.query.controller;
 
 import com.jamjam.bookjeok.common.dto.ApiResponse;
-import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.response.InterestAuthorListResponse;
 import com.jamjam.bookjeok.domains.member.query.service.InterestAuthorQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -16,16 +16,16 @@ public class InterestAuthorQueryController {
 
     private final InterestAuthorQueryService interestAuthorQueryService;
 
-    @GetMapping("/{memberId}/interest-authors")
-    public ResponseEntity<ApiResponse<List<InterestAuthorDTO>>> getInterestAuthorByMemberId(
-            @PathVariable String memberId
+    @GetMapping("/members/{memberId}/interest/authors")
+    public ResponseEntity<ApiResponse<InterestAuthorListResponse>> getInterestAuthorByMemberId(
+            @PathVariable String memberId,
+            @Validated PageRequest pageRequest
     ){
 
-        List<InterestAuthorDTO> interestAuthorList
-                = interestAuthorQueryService.getInterestAuthorList(memberId);
+        InterestAuthorListResponse interestAuthorList
+                = interestAuthorQueryService.getInterestAuthorList(memberId, pageRequest);
 
         return ResponseEntity.ok(ApiResponse.success(interestAuthorList));
-
     }
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/dto/InterestAuthorDTO.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/dto/InterestAuthorDTO.java
@@ -11,6 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 public class InterestAuthorDTO {
 
+    private Long authorId;
     private String authorName;
     private List<BookNameDTO> bookList;
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestAuthorMapper.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestAuthorMapper.java
@@ -1,15 +1,20 @@
 package com.jamjam.bookjeok.domains.member.query.mapper;
 
+import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface InterestAuthorMapper {
 
-    List<InterestAuthorDTO> findInterestAuthorByMemberId(String memberId);
+    List<InterestAuthorDTO> findInterestAuthorByMemberId(
+            @Param("memberId") String memberId,
+            @Param("pageRequest") PageRequest pageRequest
+    );
 
-    int countInterestAuthor(Long memberUid);
+    Long countInterestAuthorsByMemberId(String memberId);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/InterestAuthorQueryService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/InterestAuthorQueryService.java
@@ -1,9 +1,8 @@
 package com.jamjam.bookjeok.domains.member.query.service;
 
-import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
-
-import java.util.List;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.response.InterestAuthorListResponse;
 
 public interface InterestAuthorQueryService {
-    List<InterestAuthorDTO> getInterestAuthorList(String memberId);
+    InterestAuthorListResponse getInterestAuthorList(String memberId, PageRequest pageRequest);
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/InterestAuthorQueryServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/service/InterestAuthorQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.jamjam.bookjeok.domains.member.query.service;
 
-
+import com.jamjam.bookjeok.common.dto.Pagination;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.response.InterestAuthorListResponse;
 import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
 import com.jamjam.bookjeok.domains.member.query.mapper.InterestAuthorMapper;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +19,25 @@ public class InterestAuthorQueryServiceImpl implements InterestAuthorQueryServic
 
     @Override
     @Transactional(readOnly = true)
-    public List<InterestAuthorDTO> getInterestAuthorList(
-            String memberId
+    public InterestAuthorListResponse getInterestAuthorList(
+            String memberId,
+            PageRequest pageRequest
     ){
-        return interestAuthorMapper.findInterestAuthorByMemberId(memberId);
-    }
+        List<InterestAuthorDTO> interestAuthorList
+                = interestAuthorMapper.findInterestAuthorByMemberId(memberId,pageRequest);
 
+        long totalAuthors = interestAuthorMapper.countInterestAuthorsByMemberId(memberId);
+
+        int page = pageRequest.getPage();
+        int size = pageRequest.getSize();
+
+        return InterestAuthorListResponse.builder()
+                .interestAuthorList(interestAuthorList)
+                .pagination(Pagination.builder()
+                        .currentPage(page)
+                        .totalPage((int)Math.ceil((double)totalAuthors/size))
+                        .totalItems(totalAuthors)
+                        .build())
+                .build();
+    }
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/InterestAuthorMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/InterestAuthorMapper.xml
@@ -4,27 +4,33 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.jamjam.bookjeok.domains.member.query.mapper.InterestAuthorMapper">
     <resultMap id="authorsAndBookList" type="InterestAuthorDTO">
-        <id property="authorName" column="author_name"/>
+        <id property="authorId" column="author_id"/>
+        <result property="authorName" column="author_name"/>
         <collection property="bookList" ofType="BookNameDTO">
             <result property="bookName" column="book_name"/>
         </collection>
     </resultMap>
 
     <select id="findInterestAuthorByMemberId" resultMap="authorsAndBookList">
-        SELECT
+        SELECT DISTINCT
+            a.author_id,
             a.author_name,
             v.book_name
         FROM interest_authors ia
         JOIN authors a ON ia.author_id = a.author_id
-        JOIN book_authors ba ON a.author_id = ba.author_id
-        JOIN books v ON ba.book_id = v.book_id
+        LEFT JOIN book_authors ba ON a.author_id = ba.author_id
+        LEFT JOIN books v ON ba.book_id = v.book_id
         JOIN members m ON ia.member_uid = m.member_uid
-        WHERE m.member_id = #{ memberId };
+        WHERE m.member_id = #{ memberId }
+        ORDER BY a.author_name
+        LIMIT #{ pageRequest.limit } OFFSET #{ pageRequest.offset };
     </select>
 
-    <select id="countInterestAuthor" resultType="_int">
-        SELECT COUNT(*)
-        FROM interest_authors
-        WHERE member_uid = #{ memberUid }
+    <select id="countInterestAuthorsByMemberId" resultType="_long">
+        SELECT COUNT(DISTINCT a.author_id)
+        FROM interest_authors ia
+        JOIN authors a ON ia.author_id = a.author_id
+        JOIN members m ON ia.member_uid = m.member_uid
+        WHERE m.member_id = #{ memberId }
     </select>
 </mapper>

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/InterestAuthorQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/InterestAuthorQueryControllerTest.java
@@ -24,15 +24,14 @@ public class InterestAuthorQueryControllerTest {
     @Autowired
     MockMvc mockMvc;
 
-    @Autowired
-    ObjectMapper objectMapper;
-
     @DisplayName("멤버의 아이디로 즐겨찾기 한 작가 목록 가져오기")
     @Test
     void getInterestAuthorByMemberIdTest() throws Exception {
         String memberId = "user02";
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{memberId}/interest-authors", memberId))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/{memberId}/interest/authors", memberId)
+                        .param("page", "1")
+                        .param("size", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestAuthorMapperTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestAuthorMapperTest.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.member.query.mapper;
 
+import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
 import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,23 +23,24 @@ class InterestAuthorMapperTest {
     @DisplayName("특정 회원이 즐겨찾기한 작가 목록 가져오기")
     @Test
     void findInterestBookListTest(){
-        String memberId = "user01";
+        String memberId = "user02";
+        PageRequest pageRequest = new PageRequest(1,10);
 
-        List<InterestAuthorDTO> interestAuthorList = interestAuthorMapper.findInterestAuthorByMemberId(memberId);
+        List<InterestAuthorDTO> interestAuthorList =
+                interestAuthorMapper.findInterestAuthorByMemberId(memberId, pageRequest);
 
         assertNotNull(interestAuthorList);
         interestAuthorList.forEach(System.out::println);
 
     }
 
-    @DisplayName("회원의 관심 작가 수 가져오기")
+    @DisplayName("특정 회원의 관심 작가 수 조회하기")
     @Test
-    void countInterestAuthorTest(){
-        Long memberUid = 2L;
+    void countInterestAuthorsByMemberId(){
+        String memberId = "user02";
 
-        int totalInterestAuthor = interestAuthorMapper.countInterestAuthor(memberUid);
+        Long count = interestAuthorMapper.countInterestAuthorsByMemberId(memberId);
 
-        assertEquals(2, totalInterestAuthor);
+        assertEquals(2, count);
     }
-
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/service/InterestAuthorQueryServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/service/InterestAuthorQueryServiceImplTest.java
@@ -1,14 +1,13 @@
 package com.jamjam.bookjeok.domains.member.query.service;
 
-import com.jamjam.bookjeok.domains.member.query.dto.InterestAuthorDTO;
+import com.jamjam.bookjeok.domains.member.command.dto.request.PageRequest;
+import com.jamjam.bookjeok.domains.member.command.dto.response.InterestAuthorListResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,9 +24,11 @@ public class InterestAuthorQueryServiceImplTest {
     void findInterestAuthorByMemberIdTest(){
         String memberId = "user02";
 
-        List<InterestAuthorDTO> interestAuthorList
-                = interestAuthorQueryService.getInterestAuthorList(memberId);
+        PageRequest pageRequest = new PageRequest(1,10);
 
-        assertNotNull(interestAuthorList);
+        InterestAuthorListResponse interestAuthorResponse
+                = interestAuthorQueryService.getInterestAuthorList(memberId, pageRequest);
+
+        assertNotNull(interestAuthorResponse);
     }
 }


### PR DESCRIPTION
## ⭐로직 설명
관심 작가 페이지 구현을 위한 코드 수정 및 추가

## ✅상세 설명
- InterestAuthorQueryController
	- pagination 처리 추가
	- 응답 받는 데이터를 InterestListResponse로 수정
- InterestAuthorQueryService
	- 관심 작가를 불러오는 mapper에 페이징 처리 추가하기
	- 관심 작가의 수를 불러올 때, memberUid가 아닌 memberId를 통해 불러오는 것으로 수정
- InterestAuthorMapper
	- mapper.xml
		- 중복으로 값을 가져오기 않게 DISTINCT 추가
		- pagination 처리를 위해 Limit 부분 코드 추가
		- 책이 없는 작가도 가져올 수 있게 코드를 Left Join으로 수정
		- 회원의 관심 작가 수를 가져오는 로직에서
	- mapper.java
		- 매개변수 수정
- InterstAuthorDTO
	- authorId 가져오게 수정 (작가 상세 페이지 연결을 위함)
- 관심 작가 mapper, service, controller 테스트 수정 