### PR TITLE
[FIX] 관심 작가 추가 및 삭제 기능 수정

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/InterestAuthorCommandController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/InterestAuthorCommandController.java
@@ -17,11 +17,10 @@ public class InterestAuthorCommandController {
 
     private final InterestAuthorCommandService interestAuthorCommandService;
 
-    @PostMapping("/interest-author")
+    @PostMapping("/members/interest/authors")
     public ResponseEntity<ApiResponse<InterestAuthorResponse>> createInterestAuthor(
             @RequestBody @Validated InterestAuthorRequest request
     ){
-
         String authorName = interestAuthorCommandService.createInterestAuthor(request);
 
         InterestAuthorResponse response = InterestAuthorResponse.builder()
@@ -33,11 +32,13 @@ public class InterestAuthorCommandController {
                 .body(ApiResponse.success(response));
     }
 
-    @DeleteMapping("/interest-author")
+    @DeleteMapping("/members/{memberId}/interest/authors/{authorId}")
     public ResponseEntity<ApiResponse<Void>> deleteInterestAuthor(
-            @RequestBody @Validated InterestAuthorRequest request
+            @PathVariable String memberId,
+            @PathVariable Long authorId
+
     ){
-        interestAuthorCommandService.deleteInterestAuthor(request);
+        interestAuthorCommandService.deleteInterestAuthor(memberId, authorId);
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/InterestAuthorRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/InterestAuthorRequest.java
@@ -12,6 +12,6 @@ public class InterestAuthorRequest {
     private final String authorName;
 
     @NotNull(message = "멤버 아이디는 비어있을 수 없습니다.")
-    private final Long memberUid;
+    private final String memberId;
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/response/InterestAuthorResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/response/InterestAuthorResponse.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.member.command.dto.response;
 
+import com.jamjam.bookjeok.common.dto.Pagination;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,5 +9,7 @@ import lombok.Getter;
 public class InterestAuthorResponse {
 
     private String authorName;
+    private final Pagination pagination;
+
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/InterestAuthorRepository.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/InterestAuthorRepository.java
@@ -3,8 +3,14 @@ package com.jamjam.bookjeok.domains.member.command.repository;
 import com.jamjam.bookjeok.domains.member.command.entity.InterestAuthor;
 import com.jamjam.bookjeok.domains.member.command.entity.InterestAuthorId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InterestAuthorRepository extends JpaRepository<InterestAuthor, InterestAuthorId> {
+
+    @Query("SELECT COUNT(ia) FROM InterestAuthor ia WHERE ia.interestAuthorId.memberUid = :memberUid")
+    int countInterestAuthorsByMemberUid(@Param("memberUid") Long memberUid);
+
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/InterestAuthorCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/InterestAuthorCommandService.java
@@ -5,5 +5,5 @@ import com.jamjam.bookjeok.domains.member.command.dto.request.InterestAuthorRequ
 public interface InterestAuthorCommandService {
     String createInterestAuthor(InterestAuthorRequest request);
 
-    void deleteInterestAuthor(InterestAuthorRequest request);
+    void deleteInterestAuthor(String memberId, Long authorId);
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/InterestAuthorCommandControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/InterestAuthorCommandControllerTest.java
@@ -29,12 +29,15 @@ public class InterestAuthorCommandControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
+    String baseUrl = "/api/v1/members";
+
     @DisplayName("관심 작가 등록하기")
     @Test
     void createInterestAuthorTest() throws Exception {
-        InterestAuthorRequest request = new InterestAuthorRequest("공지영", 2L);
-
-        mockMvc.perform(post("/api/v1/interest-author")
+        String memberId = "user02";
+        InterestAuthorRequest request = new InterestAuthorRequest("공지영", memberId);
+        
+        mockMvc.perform(post("/api/v1/members/interest/authors")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -46,11 +49,11 @@ public class InterestAuthorCommandControllerTest {
     @DisplayName("관심 작가 삭제하기")
     @Test
     void deleteInterestAuthorTest() throws Exception {
-        InterestAuthorRequest request = new InterestAuthorRequest("정세랑", 2L);
+        String memberId = "user02";
+        Long authorId = 3L;
 
-        mockMvc.perform(delete("/api/v1/interest-author")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(delete(baseUrl+"/{memberId}/interest/authors/{authorId}", memberId, authorId)
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.success").value(true));
     }
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/InterestAuthorCommandServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/InterestAuthorCommandServiceImplTest.java
@@ -23,10 +23,10 @@ public class InterestAuthorCommandServiceImplTest {
     @DisplayName("관심 작가 등록하기")
     @Test
     void createInterestAuthorTest(){
-        Long memberUid = 2L;
+        String memberId = "user02";
 
         String authorName = "공지영";
-        InterestAuthorRequest request = new InterestAuthorRequest(authorName, memberUid);
+        InterestAuthorRequest request = new InterestAuthorRequest(authorName, memberId);
         String response = interestAuthorCommandService.createInterestAuthor(request);
 
         assertEquals("공지영", response);
@@ -38,26 +38,25 @@ public class InterestAuthorCommandServiceImplTest {
     @DisplayName("관심 작가 등록시 작가가 없는 경우 예외 테스트")
     @Test
     void createInterestAuthorExceptionTest1(){
-        Long memberUid = 2L;
+        String memberId = "user01";
 
         String authorName = "정유진";
-        InterestAuthorRequest request2 = new InterestAuthorRequest(authorName, memberUid);
+        InterestAuthorRequest request = new InterestAuthorRequest(authorName, memberId);
         assertThrows(AuthorNotFoundException.class, () -> {
-            interestAuthorCommandService.createInterestAuthor(request2);
+            interestAuthorCommandService.createInterestAuthor(request);
         });
     }
 
     @DisplayName("관심 작가 삭제하기")
     @Test
     void deleteInterestAuthorTest(){
-        Long memberUid = 2L;
-        String authorName = "한강";
+        String memberId = "user02";
+        Long authorId = 3L;
 
-        InterestAuthorRequest request = new InterestAuthorRequest(authorName, memberUid);
-        interestAuthorCommandService.deleteInterestAuthor(request);
+        interestAuthorCommandService.deleteInterestAuthor(memberId, authorId);
 
         assertThrows(AuthorNotFoundException.class, () -> {
-            interestAuthorCommandService.deleteInterestAuthor(request);
+            interestAuthorCommandService.deleteInterestAuthor(memberId, authorId);
         });
     }
 }


### PR DESCRIPTION
## ⭐설명
관심 작가 추가 및 삭제 기능 수정

## ✅ 상세 설명
- `InterestAuthorCommandController` 관심 작가 수정, 삭제 end-point 수정
   - 수정 : /members/interest/authors로 수정
   - 삭제 :  /members/{memberId}/interest/authors/{authorId}로 수정
- `InterestAuthorRepository`에 관심 작가의 수를 가져오는 메소드 추가
- `InterestAuthorService`에서 관심 작가의 수를 가져오는 부분 mapper의 메소드가 아닌 repository를 이용해 가져오는 것으로 수정
- mapper에서 작성한 관심 작가의 수를 가져오는 로직 삭제
- 테스트 코드 수정 