### PR TITLE
[FEATURE] 주문 상세 내역 조회 API 응답 구조 개선 및 관련 서비스 변경

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/query/mapper/OrderMapper.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/order/query/mapper/OrderMapper.java
@@ -1,0 +1,12 @@
+package com.jamjam.bookjeok.domains.order.query.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OrderMapper {
+
+    Long findOrderUidByOrderId(String orderId);
+
+    Long findPaymentIdByOrderUid(Long orderUid);
+
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryController.java
@@ -3,7 +3,6 @@ package com.jamjam.bookjeok.domains.orderdetail.query.controller;
 import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.query.service.MemberQueryService;
-import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
 import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 import com.jamjam.bookjeok.domains.orderdetail.query.service.OrderDetailQueryService;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -32,11 +29,7 @@ public class OrderDetailQueryController {
         MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
         Long memberUid = memberDetail.getMember().getMemberUid();
 
-        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId);
-
-        OrderDetailResponse orderDetailResponse = OrderDetailResponse.builder()
-                .orderDetails(orderDetails)
-                .build();
+        OrderDetailResponse orderDetailResponse = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/dto/OrderDetailBookDTO.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/dto/OrderDetailBookDTO.java
@@ -1,0 +1,10 @@
+package com.jamjam.bookjeok.domains.orderdetail.query.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OrderDetailBookDTO(
+        String bookName, String isbn,
+        int quantity, int totalPrice, String imageUrl
+) {
+}

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/dto/response/OrderDetailResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/dto/response/OrderDetailResponse.java
@@ -1,12 +1,15 @@
 package com.jamjam.bookjeok.domains.orderdetail.query.dto.response;
 
-import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailBookDTO;
+import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
 public record OrderDetailResponse(
-    List<OrderDetailDTO> orderDetails
+        String orderId, LocalDateTime orderedAt,
+        List<OrderDetailBookDTO> books, PaymentDetailDTO paymentDetail
 ) {
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryService.java
@@ -1,11 +1,9 @@
 package com.jamjam.bookjeok.domains.orderdetail.query.service;
 
-import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
-
-import java.util.List;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 
 public interface OrderDetailQueryService {
 
-    List<OrderDetailDTO> getOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId);
+    OrderDetailResponse getOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImpl.java
@@ -1,7 +1,11 @@
 package com.jamjam.bookjeok.domains.orderdetail.query.service;
 
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailBookDTO;
 import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 import com.jamjam.bookjeok.domains.orderdetail.query.mapper.OrderDetailMapper;
+import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
+import com.jamjam.bookjeok.domains.payment.query.service.PaymentDetailService;
 import com.jamjam.bookjeok.exception.orderdetail.OrderDetailNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,17 +18,37 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderDetailQueryServiceImpl implements OrderDetailQueryService {
 
+    private final PaymentDetailService paymentDetailService;
     private final OrderDetailMapper orderDetailMapper;
 
     @Override
-    public List<OrderDetailDTO> getOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId) {
+    public OrderDetailResponse getOrderDetailByMemberUidAndOrderId(Long memberUid, String orderId) {
         List<OrderDetailDTO> orderDetails = orderDetailMapper.findOrderDetailByMemberUidAndOrderId(memberUid, orderId);
 
-        if (orderDetails != null) {
-            return orderDetails;
+        if (orderDetails == null) {
+            throw new OrderDetailNotFoundException("요청하신 주문 내역은 존재하지 않습니다.");
         }
 
-        throw new OrderDetailNotFoundException("요청하신 주문 내역은 존재하지 않습니다.");
+        Long paymentId = paymentDetailService.getPaymentId(orderId);
+        PaymentDetailDTO paymentDetail = paymentDetailService.getPaymentDetail(paymentId);
+
+        List<OrderDetailBookDTO> books = orderDetails.stream()
+                .map(o -> OrderDetailBookDTO.builder()
+                        .bookName(o.bookName())
+                        .isbn(o.isbn())
+                        .quantity(o.quantity())
+                        .totalPrice(o.totalPrice())
+                        .imageUrl(o.imageUrl())
+                        .build())
+                .toList();
+
+
+        return OrderDetailResponse.builder()
+                .orderId(orderId)
+                .orderedAt(orderDetails.get(0).orderedAt())
+                .books(books)
+                .paymentDetail(paymentDetail)
+                .build();
     }
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/dto/response/PaymentConfirmResponse.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/dto/response/PaymentConfirmResponse.java
@@ -1,14 +1,10 @@
 package com.jamjam.bookjeok.domains.payment.command.dto.response;
 
-import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
-import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 import lombok.Builder;
-
-import java.util.List;
 
 @Builder
 public record PaymentConfirmResponse(
-        List<OrderDetailDTO> orderDetails,
-        PaymentDetailDTO paymentDetail
+        OrderDetailResponse orderDetails
 ) {
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/command/service/PaymentCommandServiceImpl.java
@@ -3,15 +3,14 @@ package com.jamjam.bookjeok.domains.payment.command.service;
 import com.jamjam.bookjeok.domains.book.command.service.BookStockCommandService;
 import com.jamjam.bookjeok.domains.order.command.service.OrderCommandService;
 import com.jamjam.bookjeok.domains.orderdetail.command.service.OrderDetailCommandService;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 import com.jamjam.bookjeok.domains.payment.command.entity.Payment;
-import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
 import com.jamjam.bookjeok.domains.payment.command.dto.TossPaymentApproveRequest;
 import com.jamjam.bookjeok.domains.payment.query.service.PaymentDetailService;
 import com.jamjam.bookjeok.domains.pendingorder.command.dto.request.PendingOrderBookItemsRequest;
 import com.jamjam.bookjeok.domains.order.command.entity.Order;
 import com.jamjam.bookjeok.domains.pendingorder.command.entity.PendingOrder;
 
-import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
 import com.jamjam.bookjeok.domains.orderdetail.query.service.OrderDetailQueryService;
 import com.jamjam.bookjeok.domains.payment.command.dto.PaymentDTO;
 import com.jamjam.bookjeok.domains.payment.command.dto.request.PaymentConfirmRequest;
@@ -72,16 +71,12 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         pendingOrderCommandService.deletePendingOrder(pendingOrder.getOrderId());
 
         // 주문 상세 정보 조회
-        List<OrderDetailDTO> orderDetails = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(
+        OrderDetailResponse orderDetailResponse = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(
                 savedOrder.getMemberUid(), paymentDTO.orderId()
         );
 
-        // 결제 상세 정보(결제 금액, 결제 방법)
-        PaymentDetailDTO paymentDetail = paymentDetailService.getPaymentDetail(savedPayment.getPaymentId());
-
         return PaymentConfirmResponse.builder()
-                .orderDetails(orderDetails)
-                .paymentDetail(paymentDetail)
+                .orderDetails(orderDetailResponse)
                 .build();
     }
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/query/service/PaymentDetailService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/query/service/PaymentDetailService.java
@@ -6,4 +6,6 @@ public interface PaymentDetailService {
 
     PaymentDetailDTO getPaymentDetail(Long paymentId);
 
+    Long getPaymentId(String orderId);
+
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/query/service/PaymentDetailServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/payment/query/service/PaymentDetailServiceImpl.java
@@ -1,5 +1,6 @@
 package com.jamjam.bookjeok.domains.payment.query.service;
 
+import com.jamjam.bookjeok.domains.order.query.mapper.OrderMapper;
 import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
 import com.jamjam.bookjeok.domains.payment.command.entity.Payment;
 import com.jamjam.bookjeok.domains.payment.query.mapper.PaymentDetailMapper;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PaymentDetailServiceImpl implements PaymentDetailService {
 
+    private final OrderMapper orderMapper;
     private final PaymentMapper paymentMapper;
     private final PaymentDetailMapper paymentDetailMapper;
 
@@ -25,6 +27,12 @@ public class PaymentDetailServiceImpl implements PaymentDetailService {
         String paymentMethod = findPayment.getPaymentMethod();
 
         return paymentDetailMapper.findPaymentDetailByPaymentId(paymentId, paymentMethod);
+    }
+
+    @Override
+    public Long getPaymentId(String orderId) {
+        Long orderUid = orderMapper.findOrderUidByOrderId(orderId);
+        return orderMapper.findPaymentIdByOrderUid(orderUid);
     }
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/order/OrderMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/order/OrderMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.jamjam.bookjeok.domains.order.query.mapper.OrderMapper">
+    <select id="findOrderUidByOrderId" resultType="long">
+        SELECT o.order_uid
+        FROM orders o
+        WHERE o.order_id = #{ orderId }
+    </select>
+
+    <select id="findPaymentIdByOrderUid" resultType="long">
+        SELECT p.payment_id
+        FROM orders o
+        JOIN payments p on o.order_uid = p.order_uid
+        WHERE o.order_uid = #{ orderUid }
+    </select>
+</mapper>

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/controller/OrderDetailQueryControllerTest.java
@@ -3,8 +3,11 @@ package com.jamjam.bookjeok.domains.orderdetail.query.controller;
 import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
 import com.jamjam.bookjeok.domains.member.query.dto.MemberDTO;
 import com.jamjam.bookjeok.domains.member.query.service.MemberQueryServiceImpl;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailBookDTO;
 import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 import com.jamjam.bookjeok.domains.orderdetail.query.service.OrderDetailQueryServiceImpl;
+import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,21 +41,29 @@ class OrderDetailQueryControllerTest {
     @MockBean
     private MemberQueryServiceImpl memberQueryService;
 
-    private List<OrderDetailDTO> orderDetails;
+    private OrderDetailResponse orderDetailResponse;
 
     @BeforeEach
     void setUp() {
-        orderDetails = List.of(
-                OrderDetailDTO.builder()
-                        .orderId("ORD001")
-                        .bookName("책이름01")
-                        .isbn("9781082502299")
-                        .totalPrice(15000)
-                        .quantity(1)
-                        .imageUrl("http://localhost:8080/productimgs/604248.png")
-                        .orderedAt(LocalDateTime.now().withNano(0))
-                        .build()
-        );
+        orderDetailResponse = OrderDetailResponse.builder()
+                .orderId("ORD001")
+                .orderedAt(LocalDateTime.now().withNano(0))
+                .books(List.of(
+                                OrderDetailBookDTO.builder()
+                                        .bookName("책이름01")
+                                        .isbn("9781082502299")
+                                        .quantity(1)
+                                        .totalPrice(15000)
+                                        .imageUrl("http://localhost:8080/productimgs/604248.png")
+                                        .build())
+                        )
+                .paymentDetail(
+                        PaymentDetailDTO.builder()
+                                .totalAmount(15000)
+                                .paymentMethod("토스페이")
+                                .build()
+                )
+                .build();
     }
 
     @Test
@@ -69,7 +80,7 @@ class OrderDetailQueryControllerTest {
                 .build();
 
         when(memberQueryService.getMemberDetail(memberId)).thenReturn(memberDetailResponse);
-        when(orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId)).thenReturn(orderDetails);
+        when(orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId)).thenReturn(orderDetailResponse);
 
         mockMvc.perform(get("/api/v1/members/" + memberId + "/orders/" + orderId + "/order-detail")
                 .accept(MediaType.APPLICATION_JSON)
@@ -77,15 +88,18 @@ class OrderDetailQueryControllerTest {
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.orderDetails").exists())
-                .andExpect(jsonPath("$.data.orderDetails").isArray())
-                .andExpect(jsonPath("$.data.orderDetails[0].orderId").value("ORD001"))
-                .andExpect(jsonPath("$.data.orderDetails[0].bookName").value("책이름01"))
-                .andExpect(jsonPath("$.data.orderDetails[0].isbn").value("9781082502299"))
-                .andExpect(jsonPath("$.data.orderDetails[0].totalPrice").value(15000))
-                .andExpect(jsonPath("$.data.orderDetails[0].quantity").value(1))
-                .andExpect(jsonPath("$.data.orderDetails[0].imageUrl").value("http://localhost:8080/productimgs/604248.png"))
-                .andExpect(jsonPath("$.data.orderDetails[0].orderedAt").exists())
+                .andExpect(jsonPath("$.data.orderId").exists())
+                .andExpect(jsonPath("$.data.orderId").value("ORD001"))
+                .andExpect(jsonPath("$.data.orderedAt").exists())
+                .andExpect(jsonPath("$.data.books").exists())
+                .andExpect(jsonPath("$.data.books").isArray())
+                .andExpect(jsonPath("$.data.books[0].bookName").value("책이름01"))
+                .andExpect(jsonPath("$.data.books[0].isbn").value("9781082502299"))
+                .andExpect(jsonPath("$.data.books[0].quantity").value(1))
+                .andExpect(jsonPath("$.data.books[0].totalPrice").value(15000))
+                .andExpect(jsonPath("$.data.books[0].imageUrl").value("http://localhost:8080/productimgs/604248.png"))
+                .andExpect(jsonPath("$.data.paymentDetail.totalAmount").value(15000))
+                .andExpect(jsonPath("$.data.paymentDetail.paymentMethod").value("토스페이"))
                 .andExpect(jsonPath("$.timestamp").exists());
     }
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/orderdetail/query/service/OrderDetailQueryServiceImplTest.java
@@ -1,7 +1,10 @@
 package com.jamjam.bookjeok.domains.orderdetail.query.service;
 
 import com.jamjam.bookjeok.domains.orderdetail.query.dto.OrderDetailDTO;
+import com.jamjam.bookjeok.domains.orderdetail.query.dto.response.OrderDetailResponse;
 import com.jamjam.bookjeok.domains.orderdetail.query.mapper.OrderDetailMapper;
+import com.jamjam.bookjeok.domains.payment.query.dto.PaymentDetailDTO;
+import com.jamjam.bookjeok.domains.payment.query.service.PaymentDetailService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,11 +29,16 @@ class OrderDetailQueryServiceImplTest {
     @Mock
     private OrderDetailMapper orderDetailMapper;
 
-    private List<OrderDetailDTO> orderDetails;
+    @Mock
+    private PaymentDetailService paymentDetailService;
+
+    private List<OrderDetailDTO> books;
+
+    private PaymentDetailDTO paymentDetail;
 
     @BeforeEach
     void setUp() {
-        orderDetails = List.of(
+        books = List.of(
                 OrderDetailDTO.builder()
                         .orderId("ORD001")
                         .bookName("책이름01")
@@ -41,6 +49,11 @@ class OrderDetailQueryServiceImplTest {
                         .orderedAt(LocalDateTime.now().withNano(0))
                         .build()
         );
+
+        paymentDetail = PaymentDetailDTO.builder()
+                .totalAmount(15000)
+                .paymentMethod("토스페이")
+                .build();
     }
 
     @Test
@@ -48,20 +61,24 @@ class OrderDetailQueryServiceImplTest {
     void testGetOrderDetailByMemberUidAndOrderId() {
         Long memberUid = 1L;
         String orderId = "ORD001";
+        Long paymentId = 1L;
 
-        when(orderDetailMapper.findOrderDetailByMemberUidAndOrderId(memberUid, orderId)).thenReturn(orderDetails);
+        when(orderDetailMapper.findOrderDetailByMemberUidAndOrderId(memberUid, orderId)).thenReturn(books);
+        when(paymentDetailService.getPaymentId(orderId)).thenReturn(paymentId);
+        when(paymentDetailService.getPaymentDetail(paymentId)).thenReturn(paymentDetail);
 
-        List<OrderDetailDTO> orderDetailsResult = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId);
+        OrderDetailResponse orderDetailResponse = orderDetailQueryService.getOrderDetailByMemberUidAndOrderId(memberUid, orderId);
 
-        assertNotNull(orderDetailsResult);
-        assertThat(orderDetailsResult).hasSize(1);
-        assertThat(orderDetailsResult.get(0).orderId()).isEqualTo("ORD001");
-        assertThat(orderDetailsResult.get(0).bookName()).isEqualTo("책이름01");
-        assertThat(orderDetailsResult.get(0).isbn()).isEqualTo("9781082502299");
-        assertThat(orderDetailsResult.get(0).totalPrice()).isEqualTo(15000);
-        assertThat(orderDetailsResult.get(0).quantity()).isEqualTo(1);
-        assertThat(orderDetailsResult.get(0).imageUrl()).isEqualTo("http://localhost:8080/productimgs/604248.png");
-        assertThat(orderDetailsResult.get(0).orderedAt()).isNotNull();
+        assertNotNull(orderDetailResponse);
+        assertThat(orderDetailResponse.orderId()).isEqualTo("ORD001");
+        assertThat(orderDetailResponse.books().get(0).bookName()).isEqualTo("책이름01");
+        assertThat(orderDetailResponse.books().get(0).isbn()).isEqualTo("9781082502299");
+        assertThat(orderDetailResponse.books().get(0).totalPrice()).isEqualTo(15000);
+        assertThat(orderDetailResponse.books().get(0).quantity()).isEqualTo(1);
+        assertThat(orderDetailResponse.books().get(0).imageUrl()).isEqualTo("http://localhost:8080/productimgs/604248.png");
+        assertThat(orderDetailResponse.paymentDetail().totalAmount()).isEqualTo(15000);
+        assertThat(orderDetailResponse.paymentDetail().paymentMethod()).isEqualTo("토스페이");
+        assertThat(orderDetailResponse.orderedAt()).isNotNull();
     }
 
 }


### PR DESCRIPTION
## ✔️ 변경 사항
- `OrderDetailResponse` DTO 정의 → `books`(도서 정보), `paymentDetail`(결제 정보), `orderedAt`(주문 일시)을 포함하는 통합 응답 구조 도입
- 기존 `List<OrderDetailDTO>` 반환 구조 제거 및 `OrderDetailResponse`로 일괄 변경
- `OrderDetailQueryServiceImpl` 리팩토링
  - `OrderDetailDTO → OrderDetailBookDTO` 변환 로직 추가
  - 주문 UID 조회, 결제 ID 조회, 결제 상세 정보 조회 기능 통합
- `OrderMapper.xml`에 쿼리 추가
  - `findOrderUidByOrderId(String orderId)`
  - `findPaymentIdByOrderUid(Long orderUid)`
- `PaymentDetailService`에 `getPaymentId(String orderId)` 기능 추가
- 컨트롤러 및 단위 테스트 코드 전체 수정
