### PR TITLE
[REFACTOR] 이메일 보내지는 경로 수정 및 테스트 코드 수정

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImpl.java
@@ -27,9 +27,7 @@ public class EmailCommandServiceImpl implements EmailCommandService {
         String formattedNow = now.format(formatter);
 
         // 비밀번호 재설정 링크
-        // 이 부분은 프론트 설정하면서 변경할 예정
-        // 그리고 resetLink 앞에 부분도 변경 예정
-        String resetLink = "http://localhost:8000/bookjeok-service/api/v1/password/reset?token=" + token;
+        String resetLink = "http://localhost:5173/password/reset?token=" + token;
 
         // 이메일 제목
         String subject = "Book적Book적 비밀번호 재설정 메일";
@@ -38,7 +36,6 @@ public class EmailCommandServiceImpl implements EmailCommandService {
         String to = member.getEmail();
 
         // 이메일 전체 구조 정의하는 틀
-        // 나중에 프론트 시작하면 분리할 예정
         String htmlMsg =
                 "<div style='font-family: Arial, sans-serif; padding: 20px; background-color: #f4f4f4;'>"
                 + "  <div style='max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 30px; border-radius: 10px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);'>"

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/EmailCommandServiceImplTest.java
@@ -3,29 +3,29 @@ package com.jamjam.bookjeok.domains.member.command.service;
 import com.jamjam.bookjeok.domains.member.command.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ActiveProfiles("test")
-@Transactional
-@SpringBootTest
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
 class EmailCommandServiceImplTest {
 
-    @Autowired
+    @Mock
     private EmailCommandService emailCommandService;
 
     @DisplayName("비밀번호 재설정 이메일 보내기 테스트")
     @Test
     void sendPasswordResetEmailTest() throws Exception {
         Member member = Member.builder()
-                .email("bookjeok@bookjeok.com")
+                .email("jamjam123@bookbook.com")
                 .memberId("jamjam123")
                 .build();
-
         String token = "mock-token-123";
 
         emailCommandService.sendPasswordResetEmail(member, token);
+
+        verify(emailCommandService).sendPasswordResetEmail(member, token);
     }
 }


### PR DESCRIPTION
- `EmailCommandServiceImpl` 비밀번호 재설정 링크 프론트엔드 링크로 변경
- `EmailCommandServiceImplTest` mock을 이용하는 것으로 테스트 수정