### PR TITLE
[FIX]  팔로우 관련 기능 프론트와 연결되게 수정

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/FollowCommandController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/FollowCommandController.java
@@ -19,8 +19,7 @@ public class FollowCommandController {
 
     private final FollowCommandService followCommandService;
 
-    // 로그인 끝나면 이 부분 수정하기
-    @PostMapping("/{followerId}/follow")
+    @PostMapping("/members/{followerId}/followings")
     public ResponseEntity<ApiResponse<FollowMemberResponse>> createFollow(
             @RequestBody @Validated FollowMemberRequest followMemberRequest,
             @PathVariable String followerId
@@ -42,12 +41,11 @@ public class FollowCommandController {
                 .body(ApiResponse.success(response));
     }
 
-    @DeleteMapping("/{followerId}/follow")
+    @DeleteMapping("members/{followerId}/followings/{followingId}")
     public ResponseEntity<ApiResponse<Void>> deleteFollow(
-            @RequestBody @Validated FollowMemberRequest followMemberRequest,
-            @PathVariable String followerId
+            @PathVariable String followerId,
+            @PathVariable String followingId
     ){
-        String followingId = followMemberRequest.getFollowingId();
 
         log.info("followingId : {}", followingId);
         log.info("followerId : {}", followerId);

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/FollowQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/FollowQueryController.java
@@ -19,7 +19,7 @@ public class FollowQueryController {
 
     private final FollowQueryService followQueryService;
 
-    @GetMapping("/{memberId}/followings")
+    @GetMapping("/members/{memberId}/followings")
     public ResponseEntity<ApiResponse<List<FollowDTO>>> getFollowListByMemberUid(
             @PathVariable String memberId
     ){
@@ -28,7 +28,7 @@ public class FollowQueryController {
         return ResponseEntity.ok(ApiResponse.success(followList));
     }
 
-    @GetMapping("/{writerId}/postList")
+    @GetMapping("/{writerId}/posts")
     public ResponseEntity<ApiResponse<List<PostSummaryDTO>>> getPostListByWriterId(
             @PathVariable String writerId
     ){

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/dto/PostSummaryDTO.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/dto/PostSummaryDTO.java
@@ -1,6 +1,11 @@
 package com.jamjam.bookjeok.domains.member.query.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
 @ToString
@@ -10,5 +15,7 @@ public class PostSummaryDTO {
 
     private String nickname;
     private String title;
+    private String content;
+    private LocalDateTime createdAt;
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/FollowMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/FollowMapper.xml
@@ -23,7 +23,9 @@
         SELECT
             p.writer_uid,
             m.nickname,
-            p.title
+            p.title,
+            p.content,
+            p.created_at
         FROM posts p
         JOIN members m ON p.writer_uid = m.member_uid
         WHERE m.activity_status = 'ACTIVE'

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/FollowCommandControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/FollowCommandControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -29,6 +30,8 @@ class FollowCommandControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
+    String baseUrl = "/api/v1/members";
+
     @DisplayName("팔로우 하기 테스트")
     @Test
     void createFollowTest() throws Exception {
@@ -37,7 +40,7 @@ class FollowCommandControllerTest {
 
         FollowMemberRequest followMemberRequest = new FollowMemberRequest(followingId);
 
-        mockMvc.perform(post("/api/v1/{followerId}/follow", followerId)
+        mockMvc.perform(post(baseUrl + "/{followerId}/followings", followerId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(followMemberRequest)))
                 .andExpect(status().isCreated())
@@ -54,7 +57,7 @@ class FollowCommandControllerTest {
 
         FollowMemberRequest followMemberRequest = new FollowMemberRequest(followingId);
 
-        mockMvc.perform(delete("/api/v1/{followerId}/follow", followerId)
+        mockMvc.perform(delete(baseUrl+ "/{followerId}/followings/{followingId}", followerId, followingId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(followMemberRequest)))
                 .andExpect(jsonPath("$.success").value(true));

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/FollowQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/FollowQueryControllerTest.java
@@ -1,6 +1,5 @@
 package com.jamjam.bookjeok.domains.member.query.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,15 +23,14 @@ class FollowQueryControllerTest {
     @Autowired
     MockMvc mockMvc;
 
-    @Autowired
-    ObjectMapper objectMapper;
+    String baseUrl = "/api/v1";
 
     @DisplayName("특정 멤버의 팔로우 목록 가져오기")
     @Test
     void getFollowListByMemberUidTest() throws Exception {
         String memberId = "user01";
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{memberId}/followings", memberId))
+        mockMvc.perform(MockMvcRequestBuilders.get(baseUrl + "/members/{memberId}/followings", memberId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())
@@ -49,7 +47,7 @@ class FollowQueryControllerTest {
     void getPostListByWriterIdTest() throws Exception {
         String writerId = "user02";
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/{writerId}/postList", writerId))
+        mockMvc.perform(MockMvcRequestBuilders.get(baseUrl+ "/{writerId}/posts", writerId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())


### PR DESCRIPTION
## ✅ 수정 사항 내용
- `FollowCommandControllerTest` end-point 경로 수정하기 (members 추가)
- `FollowQueryControllerTest` end-point 경로 수정하기
- `FollowMapper`에서 팔로잉 하는 사람의 게시글 목록 가져오기 내용과 생성날짜 가져오게 수정
- `FollowQueryController`에서 end-point 수정하기
	- 팔로우 리스트를 가져오는 부분 members추가하기 
	- 팔로우하는 사람의 게시글 목록을 가져오는 부분 postList -> posts
- `FollowCommandController`
	- end-point에 members 추가하기
	- 팔로잉 삭제 시 PathVarivable로 받게 매개변수 수정

