### PR TITLE
[REFACTOR] 장바구니 등록, 수정, 삭제 엔드포인트를 `members/{memberId}/carts`로 변경

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/command/controller/CartCommandController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/command/controller/CartCommandController.java
@@ -4,6 +4,8 @@ import com.jamjam.bookjeok.common.dto.ApiResponse;
 import com.jamjam.bookjeok.domains.cart.command.service.CartCommandService;
 import com.jamjam.bookjeok.domains.cart.command.dto.request.CartRequest;
 import com.jamjam.bookjeok.domains.cart.command.dto.response.CartResponse;
+import com.jamjam.bookjeok.domains.member.command.dto.response.MemberDetailResponse;
+import com.jamjam.bookjeok.domains.member.query.service.MemberQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,35 +17,48 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CartCommandController {
 
+    private final MemberQueryService memberQueryService;
     private final CartCommandService cartCommandService;
 
-    @PostMapping("/carts")
+    @PostMapping("/members/{memberId}/carts")
     public ResponseEntity<ApiResponse<CartResponse>> createBookToCart(
+            @PathVariable(value = "memberId") String memberId,
             @RequestBody @Validated CartRequest cartRequest
     ) {
-        CartResponse cartResponse = cartCommandService.createBookToCart(cartRequest);
+        MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
+        Long memberUid = memberDetail.getMember().getMemberUid();
+
+        CartResponse cartResponse = cartCommandService.createBookToCart(memberUid, cartRequest);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(cartResponse));
     }
 
-    @PutMapping("/carts")
+    @PutMapping("/members/{memberId}/carts")
     public ResponseEntity<ApiResponse<CartResponse>> modifyBookQuantity(
+            @PathVariable(value = "memberId") String memberId,
             @RequestBody @Validated CartRequest cartRequest
     ) {
-        CartResponse cartResponse = cartCommandService.modifyBookQuantity(cartRequest);
+        MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
+        Long memberUid = memberDetail.getMember().getMemberUid();
+
+        CartResponse cartResponse = cartCommandService.modifyBookQuantity(memberUid, cartRequest);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(cartResponse));
     }
 
-    @DeleteMapping("/carts")
+    @DeleteMapping("/members/{memberId}/carts")
     public ResponseEntity<ApiResponse<CartResponse>> deleteBookFromCartByMemberId(
+            @PathVariable(value = "memberId") String memberId,
             @RequestBody @Validated CartRequest cartRequest
     ) {
-        cartCommandService.deleteBookFromCartByMemberId(cartRequest);
+        MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
+        Long memberUid = memberDetail.getMember().getMemberUid();
+
+        cartCommandService.deleteBookFromCartByMemberId(memberUid, cartRequest);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/command/dto/request/CartRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/command/dto/request/CartRequest.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 
 @Builder
 public record CartRequest(
-        @NotNull(message = "memberUid는 비어있을 수 없습니다.") Long memberUid,
         @NotNull(message = "bookId는 비어있을 수 없습니다.") Long bookId,
         @NotBlank(message = "책 이름은 비어있을 수 없습니다.") String bookName,
         @Min(value = 1, message = "책의 수량은 1개 보다 작을 수 없습니다.") int quantity

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/command/service/CartCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/command/service/CartCommandService.java
@@ -5,10 +5,10 @@ import com.jamjam.bookjeok.domains.cart.command.dto.response.CartResponse;
 
 public interface CartCommandService {
 
-    CartResponse createBookToCart(CartRequest cartRequest);
+    CartResponse createBookToCart(Long memberUid, CartRequest cartRequest);
 
-    CartResponse modifyBookQuantity(CartRequest cartRequest);
+    CartResponse modifyBookQuantity(Long memberUid, CartRequest cartRequest);
 
-    void deleteBookFromCartByMemberId(CartRequest cartRequest);
+    void deleteBookFromCartByMemberId(Long memberUid, CartRequest cartRequest);
 
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/query/controller/CartQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/cart/query/controller/CartQueryController.java
@@ -23,8 +23,9 @@ public class CartQueryController {
             @PathVariable(value = "memberId") String memberId
     ) {
         MemberDetailResponse memberDetail = memberQueryService.getMemberDetail(memberId);
+        Long memberUid = memberDetail.getMember().getMemberUid();
 
-        CartBookListResponse cartBookListResponse = cartQueryService.getBooksInCart(memberDetail.getMember().getMemberUid());
+        CartBookListResponse cartBookListResponse = cartQueryService.getBooksInCart(memberUid);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/cart/command/controller/CartCommandControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/cart/command/controller/CartCommandControllerTest.java
@@ -32,14 +32,14 @@ class CartCommandControllerTest {
     @Test
     @DisplayName("장바구니에 도서를 등록하는 테스트")
     void testCreateBookToCart() throws Exception {
+        String memberId = "user01";
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(33L)
                 .bookName("문학으로 본 심리학")
                 .quantity(10)
                 .build();
 
-        mockMvc.perform(post("/api/v1/carts")
+        mockMvc.perform(post("/api/v1/members/" + memberId + "/carts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(cartRequest))
@@ -61,13 +61,13 @@ class CartCommandControllerTest {
     @Test
     @DisplayName("장바구니에 도서를 등록할 때 필요한 정보[책 이름]가 없으면 예외가 발생하는 테스트")
     void testCreateBookToCartException() throws Exception {
+        String memberId = "user01";
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(2L)
                 .quantity(10)
                 .build();
 
-        mockMvc.perform(post("/api/v1/carts")
+        mockMvc.perform(post("/api/v1/members/" + memberId + "/carts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(cartRequest))
@@ -81,14 +81,14 @@ class CartCommandControllerTest {
     @Test
     @DisplayName("장바구니에 있는 도서 수량을 변경하는 테스트")
     void testModifyBookQuantity() throws Exception {
+        String memberId = "user01";
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(1L)
                 .bookName("우리가 빛의 속도로 갈 수 없다면")
                 .quantity(5)
                 .build();
 
-        mockMvc.perform(put("/api/v1/carts")
+        mockMvc.perform(put("/api/v1/members/" + memberId + "/carts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(cartRequest))
@@ -110,14 +110,14 @@ class CartCommandControllerTest {
     @Test
     @DisplayName("장바구니에 도서 정보가 없을 때 수량 변경을 시도하면 예외가 발생하는 테스트")
     void testModifyBookQuantityException() throws Exception {
+        String memberId = "user01";
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(3L)
                 .bookName("노르웨이의 숲")
                 .quantity(7)
                 .build();
 
-        mockMvc.perform(put("/api/v1/carts")
+        mockMvc.perform(put("/api/v1/members/" + memberId + "/carts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(cartRequest))
@@ -131,14 +131,14 @@ class CartCommandControllerTest {
     @Test
     @DisplayName("장바구니에 있는 도서 정보를 삭제하는 테스트")
     void testDeleteBookFromCartByMemberId() throws Exception {
+        String memberId = "user01";
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(1L)
                 .bookName("우리가 빛의 속도로 갈 수 없다면")
                 .quantity(10)
                 .build();
 
-        mockMvc.perform(delete("/api/v1/carts")
+        mockMvc.perform(delete("/api/v1/members/" + memberId + "/carts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(cartRequest))
@@ -153,14 +153,14 @@ class CartCommandControllerTest {
     @Test
     @DisplayName("장바구니에 없는 도서 정보를 삭제할 때 예외가 발생하는 테스트")
     void testDeleteBookFromCartByMemberIdException() throws Exception {
+        String memberId = "user01";;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(100L)
                 .bookName("Clean Code")
                 .quantity(1)
                 .build();
 
-        mockMvc.perform(delete("/api/v1/carts")
+        mockMvc.perform(delete("/api/v1/members/" + memberId + "/carts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(cartRequest))

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/cart/command/service/CartCommandServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/cart/command/service/CartCommandServiceImplTest.java
@@ -27,14 +27,14 @@ class CartCommandServiceImplTest {
     @Test
     @DisplayName("장바구니에 도서 정보 추가하는 테스트")
     void testCreateBookToCart() {
+        Long memberUid = 1L;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(33L)
                 .bookName("문학으로 본 심리학")
                 .quantity(10)
                 .build();
 
-        CartResponse cartResponse = cartCommandService.createBookToCart(cartRequest);
+        CartResponse cartResponse = cartCommandService.createBookToCart(memberUid, cartRequest);
 
         log.info("cartResponse: {}", cartResponse.toString());
 
@@ -50,14 +50,14 @@ class CartCommandServiceImplTest {
     @Test
     @DisplayName("장바구니에 도서 정보 추가할 때 동일한 도서 정보가 있으면 수량을 증가시키는 테스트")
     void testCreateBookToCartAddQuantity() {
+        Long memberUid = 1L;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(1L)
                 .bookName("우리가 빛의 속도로 갈 수 없다면")
                 .quantity(5)
                 .build();
 
-        CartResponse cartResponse = cartCommandService.createBookToCart(cartRequest);
+        CartResponse cartResponse = cartCommandService.createBookToCart(memberUid, cartRequest);
 
         log.info("cartResponse: {}", cartResponse.toString());
 
@@ -73,14 +73,14 @@ class CartCommandServiceImplTest {
     @Test
     @DisplayName("장바구니에 도서 정보가 존재하는 경우 도서 수량을 변경하는 테스트")
     void testModifyBookQuantity() {
+        Long memberUid = 1L;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(1L)
                 .bookName("우리가 빛의 속도로 갈 수 없다면")
                 .quantity(3)
                 .build();
 
-        CartResponse cartResponse = cartCommandService.modifyBookQuantity(cartRequest);
+        CartResponse cartResponse = cartCommandService.modifyBookQuantity(memberUid, cartRequest);
 
         log.info("cartResponse: {}", cartResponse.toString());
 
@@ -95,14 +95,14 @@ class CartCommandServiceImplTest {
     @Test
     @DisplayName("장바구니에서 도서 수량을 변경할 때, 도서 정보가 존재하지 않으면 예외가 발생하는 테스트")
     void testModifyBookQuantityException() {
+        Long memberUid = 1L;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(32L)
                 .bookName("다 함께 쓰는 여행기")
                 .quantity(3)
                 .build();
 
-        assertThatThrownBy(() -> cartCommandService.modifyBookQuantity(cartRequest))
+        assertThatThrownBy(() -> cartCommandService.modifyBookQuantity(memberUid, cartRequest))
                 .isInstanceOf(CartBookNotFoundException.class)
                 .hasMessage("장바구니에 해당 도서 정보가 없습니다.");
     }
@@ -110,27 +110,27 @@ class CartCommandServiceImplTest {
     @Test
     @DisplayName("memberUid와 bookId로 장바구니에 있는 도서 정보 삭제하는 테스트")
     void testDeleteBookFromCartByMemberId() {
+        Long memberUid = 1L;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(1L)
                 .bookName("우리가 빛의 속도로 갈 수 없다면")
                 .quantity(10)
                 .build();
 
-        assertDoesNotThrow(() -> cartCommandService.deleteBookFromCartByMemberId(cartRequest));
+        assertDoesNotThrow(() -> cartCommandService.deleteBookFromCartByMemberId(memberUid, cartRequest));
     }
 
     @Test
     @DisplayName("장바구니에 없는 도서 정보를 삭제할 때 예외가 발생하는 테스트")
     void testDeleteBookFromCartByMemberIdException() {
+        Long memberUid = 1L;
         CartRequest cartRequest = CartRequest.builder()
-                .memberUid(1L)
                 .bookId(2L)
                 .bookName("채식주의자")
                 .quantity(1)
                 .build();
 
-        assertThatThrownBy(() -> cartCommandService.deleteBookFromCartByMemberId(cartRequest))
+        assertThatThrownBy(() -> cartCommandService.deleteBookFromCartByMemberId(memberUid, cartRequest))
                 .isInstanceOf(CartBookNotFoundException.class)
                 .hasMessage("장바구니에 해당 도서 정보가 없습니다.");
     }


### PR DESCRIPTION
## ✔️ 변경 사항
- 장바구니와 관련된 모든 작업(등록, 수정, 삭제, 조회)을 동일한 패턴을 따르도록 하여 API 구조의 일관성 확보
- `CartCommandController`에 `MemberQueryService` 의존성 주입을 통해 memberId로 memberUid를 조회하는 기능을 추가
- 엔드포인트 변경에 따른 테스트 코드 수정