### PR TITLE
[FEATURE] 프론트에 맞게 관심 도서 기능 추가 및 수정

### DIFF
--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/InterestBookCommandController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/controller/InterestBookCommandController.java
@@ -17,13 +17,11 @@ public class InterestBookCommandController {
 
     private final InterestBookCommandService interestBookCommandService;
 
-    @PostMapping("/interest-book")
+    @PostMapping("/members/interest/books")
     public ResponseEntity<ApiResponse<InterestBookResponse>> createInterestBook(
-            @RequestBody @Validated InterestBookRequest request
+            @RequestBody @Validated InterestBookRequest interestBookRequest
     ){
-        Long memberUid = 1L;
-
-        String bookName = interestBookCommandService.createInterestBook(memberUid, request);
+        String bookName = interestBookCommandService.createInterestBook(interestBookRequest);
 
         InterestBookResponse response = InterestBookResponse.builder()
                 .bookName(bookName)
@@ -34,14 +32,13 @@ public class InterestBookCommandController {
                 .body(ApiResponse.success(response));
     }
 
-    @DeleteMapping("/interest-book")
+    @DeleteMapping("/members/{memberId}/interest/books/{bookId}")
     public ResponseEntity<ApiResponse<Void>> deleteInterestBook(
-            @RequestBody @Validated InterestBookRequest request
+            @PathVariable String memberId,
+            @PathVariable Long bookId
     ){
-        // 로그인 연결 후 수정
-        Long memberUid = 1L;
 
-        interestBookCommandService.deleteInterestBook(memberUid, request);
+        interestBookCommandService.deleteInterestBook(memberId, bookId);
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/InterestBookRequest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/dto/request/InterestBookRequest.java
@@ -11,4 +11,7 @@ public class InterestBookRequest {
     @NotNull(message = "책의 아이디는 비어있을 수 없습니다.")
     private final Long bookId;
 
+    @NotNull(message = "멤버 아이디는 비어있을 수 없습니다.")
+    private final String memberId;
+
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/InterestBookRepository.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/repository/InterestBookRepository.java
@@ -3,10 +3,15 @@ package com.jamjam.bookjeok.domains.member.command.repository;
 import com.jamjam.bookjeok.domains.member.command.entity.InterestBook;
 import com.jamjam.bookjeok.domains.member.command.entity.InterestBookId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InterestBookRepository extends JpaRepository<InterestBook, InterestBookId> {
+
+    @Query("SELECT COUNT(ib) FROM InterestBook ib WHERE ib.interestBookId.memberUid = :memberUid")
+    int countInterestBookByMemberUid(@Param("memberUid") Long memberUid);
 
     boolean existsById(InterestBookId interestBookId);
 

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/InterestBookCommandService.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/InterestBookCommandService.java
@@ -3,7 +3,7 @@ package com.jamjam.bookjeok.domains.member.command.service;
 import com.jamjam.bookjeok.domains.member.command.dto.request.InterestBookRequest;
 
 public interface InterestBookCommandService {
-    String createInterestBook(Long memberUid, InterestBookRequest request);
+    String createInterestBook(InterestBookRequest request);
 
-    void deleteInterestBook(Long memberUid, InterestBookRequest request);
+    void deleteInterestBook(String memberId, Long bookId);
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/InterestBookCommandServiceImpl.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/command/service/InterestBookCommandServiceImpl.java
@@ -5,9 +5,12 @@ import com.jamjam.bookjeok.domains.book.command.repository.BookRepository;
 import com.jamjam.bookjeok.domains.member.command.dto.request.InterestBookRequest;
 import com.jamjam.bookjeok.domains.member.command.entity.InterestBook;
 import com.jamjam.bookjeok.domains.member.command.entity.InterestBookId;
+import com.jamjam.bookjeok.domains.member.command.entity.Member;
 import com.jamjam.bookjeok.domains.member.command.repository.InterestBookRepository;
-import com.jamjam.bookjeok.domains.member.query.mapper.InterestBookMapper;
+import com.jamjam.bookjeok.domains.member.command.repository.MemberRepository;
+import com.jamjam.bookjeok.domains.member.query.mapper.MemberMapper;
 import com.jamjam.bookjeok.exception.member.MemberErrorCode;
+import com.jamjam.bookjeok.exception.member.MemberException;
 import com.jamjam.bookjeok.exception.member.interestBookException.AlreadyInterestedBookException;
 import com.jamjam.bookjeok.exception.member.interestBookException.InterestBookLimitExceededException;
 import com.jamjam.bookjeok.exception.member.interestBookException.NotFoundBookException;
@@ -23,16 +26,21 @@ public class InterestBookCommandServiceImpl implements InterestBookCommandServic
 
     private final BookRepository bookRepository;
     private final InterestBookRepository interestBookRepository;
-    private final InterestBookMapper interestBookMapper;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
     public String createInterestBook(
-            Long memberUid, // 로그인 부분 완성 되면 제거 -> 로그인 된 사용자를 가져오면 됨
             InterestBookRequest interestBookRequest
     ){
 
-        int totalInterestedBook = interestBookMapper.countInterestBookByMemberUid(memberUid);
+        Member member = memberRepository.findByMemberId(interestBookRequest.getMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_EXIST_MEMBER));
+
+
+        Long memberUid = member.getMemberUid();
+
+        int totalInterestedBook = interestBookRepository.countInterestBookByMemberUid(memberUid);
 
         log.info("관심도서의 수는 : {}", totalInterestedBook);
 
@@ -65,15 +73,12 @@ public class InterestBookCommandServiceImpl implements InterestBookCommandServic
 
     @Override
     @Transactional
-    public void deleteInterestBook(
-            Long memberUid, // 로그인 부분 완성 되면 제거 -> 로그인 된 사용자를 가져오면 됨
-            InterestBookRequest interestBookRequest
-    ){
-        Book book = bookRepository.findBookByBookId(interestBookRequest.getBookId())
-                .orElseThrow(() -> new NotFoundBookException(MemberErrorCode.NOT_FOUND_BOOK));
+    public void deleteInterestBook(String memberId, Long bookId){
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_EXIST_MEMBER));
 
         InterestBookId interestBookId
-                = new InterestBookId(interestBookRequest.getBookId(), memberUid);
+                = new InterestBookId(bookId, member.getMemberUid());
 
         InterestBook interestBook = interestBookRepository.findById(interestBookId)
                 .orElseThrow(() -> new NotFoundBookException(MemberErrorCode.NOT_REGIST_INTEREST_BOOK));

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/InterestBookQueryController.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/controller/InterestBookQueryController.java
@@ -16,7 +16,7 @@ public class InterestBookQueryController {
 
     private final InterestBookQueryService interestBookQueryService;
 
-    @GetMapping("/{memberId}/interest-books")
+    @GetMapping("/members/{memberId}/interest/books")
     public ResponseEntity<ApiResponse<InterestBookListResponse>> getInterestBooListByMemberId(
             @PathVariable String memberId,
             @Validated PageRequest pageRequest

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/dto/InterestBookDTO.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/dto/InterestBookDTO.java
@@ -8,6 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 public class InterestBookDTO {
 
+    private Long bookId;
     private String bookName;
     private String bookInfo;
     private String imageUrl;

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestBookMapper.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestBookMapper.java
@@ -14,7 +14,4 @@ public interface InterestBookMapper {
             @Param("memberId") String memberId,
             @Param("pageRequest") PageRequest pageRequest
     );
-
-    int countInterestBookByMemberUid(Long memberUid);
-
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/InterestBookMapper.xml
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/main/resources/mappers/member/InterestBookMapper.xml
@@ -5,6 +5,7 @@
 <mapper namespace="com.jamjam.bookjeok.domains.member.query.mapper.InterestBookMapper">
     <select id="findInterestBookList" resultType="InterestBookDTO">
         SELECT
+            b.book_id,
             b.book_name,
             b.book_info,
             b.image_url,
@@ -15,12 +16,7 @@
         JOIN authors a ON ba.author_id = a.author_id
         JOIN members m ON ib.member_uid = m.member_uid
         WHERE m.member_id = #{ memberId }
+        ORDER BY b.book_name
         LIMIT #{ pageRequest.limit } OFFSET #{ pageRequest.offset };
-    </select>
-
-    <select id="countInterestBookByMemberUid" resultType="_int">
-        SELECT COUNT(*)
-        FROM interest_books
-        WHERE member_uid = #{ memberUid }
     </select>
 </mapper>

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/InterestBookCommandControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/controller/InterestBookCommandControllerTest.java
@@ -29,12 +29,16 @@ class InterestBookCommandControllerTest {
     @Autowired
     ObjectMapper objectMapper;
 
+    String baseUrl = "/api/v1/members";
+
     @DisplayName("관심 도서 등록하기")
     @Test
     void createInterestBookTest() throws Exception {
-        InterestBookRequest request = new InterestBookRequest(5L);
+        String memberId = "user01";
+        Long bookId = 5L;
+        InterestBookRequest request = new InterestBookRequest(bookId, memberId);
 
-        mockMvc.perform(post("/api/v1/interest-book")
+        mockMvc.perform(post(baseUrl + "/interest/books")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -46,11 +50,13 @@ class InterestBookCommandControllerTest {
     @DisplayName("관심 도서 삭제하기")
     @Test
     void deleteInterestBookTest() throws Exception {
-        InterestBookRequest request = new InterestBookRequest(2L);
+        String memberId = "user02";
+        Long bookId = 2L;
 
-        mockMvc.perform(delete("/api/v1/interest-book")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        InterestBookRequest request = new InterestBookRequest(2L, memberId);
+
+        mockMvc.perform(delete(baseUrl + "/{memberId}/interest/books/{bookId}", memberId, bookId)
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.success").value(true));
     }
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/InterestBookCommandServiceImplTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/command/service/InterestBookCommandServiceImplTest.java
@@ -23,46 +23,50 @@ class InterestBookCommandServiceImplTest {
     @DisplayName("관심 도서 추가하기")
     @Test
     void createInterestedBook(){
-        Long memberUid = 1L;
-        InterestBookRequest request = new InterestBookRequest(1L);
+        String memberId = "user01";
+        Long bookId = 5L;
+        InterestBookRequest request = new InterestBookRequest(bookId, memberId);
 
         String bookName
-                = interestBookCommandService.createInterestBook(memberUid, request);
+                = interestBookCommandService.createInterestBook(request);
 
-        assertEquals("우리가 빛의 속도로 갈 수 없다면", bookName);
+        assertEquals("노르웨이의 숲", bookName);
     }
 
     @DisplayName("없는 책이라면 발생하는 예외")
     @Test
     void notFoundBookExceptionTest(){
-        Long memberUid = 1L;
-        InterestBookRequest request = new InterestBookRequest(1000L);
+        String memberId = "user01";
+        Long bookId = 1000L;
+
+        InterestBookRequest request = new InterestBookRequest(bookId, memberId);
 
         assertThrows(NotFoundBookException.class,
-                () ->  interestBookCommandService.createInterestBook(memberUid, request));
+                () ->  interestBookCommandService.createInterestBook(request));
     }
 
     @DisplayName("이미 즐겨찾기에 등록된 도서일 경우 발생하는 예외")
     @Test
     void alreadyInterestedBookExceptionTest(){
-        Long memberUid = 1L;
-        InterestBookRequest request = new InterestBookRequest(2L);
+        String memberId = "user01";
+        Long bookId = 2L;
+
+        InterestBookRequest request = new InterestBookRequest(bookId, memberId);
 
         assertThrows(AlreadyInterestedBookException.class,
-                () ->  interestBookCommandService.createInterestBook(memberUid, request));
+                () ->  interestBookCommandService.createInterestBook(request));
     }
 
     @DisplayName("관심 도서 삭제 후 존재 여부 확인해 예외 발생")
     @Test
     void deleteInterestAuthorTest(){
-        Long memberUid = 2L;
+        String memberId = "user02";
+        Long bookId = 2L;
 
-        InterestBookRequest request = new InterestBookRequest(2L);
-
-        interestBookCommandService.deleteInterestBook(memberUid, request);
+        interestBookCommandService.deleteInterestBook(memberId, bookId);
 
         assertThrows(NotFoundBookException.class, () -> {
-            interestBookCommandService.deleteInterestBook(memberUid, request);
+            interestBookCommandService.deleteInterestBook(memberId, bookId);
         });
     }
 }

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/InterestBookQueryControllerTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/controller/InterestBookQueryControllerTest.java
@@ -1,6 +1,5 @@
 package com.jamjam.bookjeok.domains.member.query.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,16 +23,13 @@ class InterestBookQueryControllerTest {
     @Autowired
     MockMvc mockMvc;
 
-    @Autowired
-    ObjectMapper objectMapper;
-
     @DisplayName("멤버의 아이디로 책 즐겨찾기 목록 가져오기 테스트")
     @Test
     void getInterestBooListByMemberIdTest() throws Exception {
         String memberId = "user01";
 
         mockMvc.perform(MockMvcRequestBuilders
-                        .get("/api/v1/{memberId}/interest-books", memberId)
+                        .get("/api/v1/members/{memberId}/interest/books", memberId)
                         .param("page", "1")
                         .param("size", "2"))
                 .andExpect(status().isOk())

--- a/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestBookMapperTest.java
+++ b/be15-jamjam-bookjeok-msa/be15-2nd-jamjam-bookjeok/src/test/java/com/jamjam/bookjeok/domains/member/query/mapper/InterestBookMapperTest.java
@@ -30,15 +30,4 @@ class InterestBookMapperTest {
 
         assertNotNull(bookList);
     }
-
-    @DisplayName("특정 회원의 관심 도서의 수 가져오기")
-    @Test
-    void countInterestBookByMemberUidTest(){
-        Long memberUid = 2L;
-
-        int count = interestBookMapper.countInterestBookByMemberUid(memberUid);
-
-        assertEquals(2, count);
-    }
-
 }


### PR DESCRIPTION
## ⭐ 기능 설명
프론트에 맞게 관심 도서 기능 추가 및 수정

## ✅ 상세 설명
- `InterestBookCommandController` 관심 작가 수정, 삭제 end-point 수정
	- 수정 : /members/interest/books로 수정
	- 삭제 : /members/{memberId}/interest/books/{bookId}로 수정
- `InterestBookRepository`에 관심의 도서의 수를 가져오는 메소드 추가
- `InterestBookCommandService`에서 관심 작가의 수를 가져오는 부분 mapper의 메소드가 아닌 repository를 이용해 가져오는 것으로 수정
- `InterestBookDTO` : 관심 도서의 bookId 필드 추가
- `InterestBookmapper`에서 작성한 관심 도서의 수를 가져오는 로직 삭제 및 관심 도서 조회 시 bookId 조회 추가
- 테스트 코드 수